### PR TITLE
Reduce the number of structs and indirection in RCAN v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,15 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "bijoux"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f5eadb0ba4626106dcf5b84ac1009074b0aa90f06e4351846e58e9787337be"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,7 +663,6 @@ name = "rcan"
 version = "0.5.0"
 dependencies = [
  "assert_matches",
- "bijoux",
  "ciborium",
  "data-encoding",
  "data-encoding-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
+name = "data-encoding-macro"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
+dependencies = [
+ "data-encoding",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +675,7 @@ dependencies = [
  "bijoux",
  "ciborium",
  "data-encoding",
+ "data-encoding-macro",
  "derive_more",
  "ed25519-dalek",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bijoux"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f5eadb0ba4626106dcf5b84ac1009074b0aa90f06e4351846e58e9787337be"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +652,7 @@ name = "rcan"
 version = "0.5.0"
 dependencies = [
  "assert_matches",
+ "bijoux",
  "ciborium",
  "data-encoding",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bijoux = "0.3"
 derive_more = { version = "2.0.1", features = ["debug", "display"] }
 ed25519-dalek = { version = ">=3.0.0-rc.0,<4.0.0", features = ["serde"] }
 data-encoding = "2"
+data-encoding-macro = "0.1"
 n0-error = "1"
 hex = "0.4.3"
 n0-future = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/n0-computer/rcan"
 rust-version = "1.91"
 
 [dependencies]
-bijoux = "0.3"
 derive_more = { version = "2.0.1", features = ["debug", "display"] }
 ed25519-dalek = { version = ">=3.0.0-rc.0,<4.0.0", features = ["serde"] }
 data-encoding = "2"
@@ -19,9 +18,9 @@ data-encoding-macro = "0.1"
 n0-error = "1"
 hex = "0.4.3"
 n0-future = "0.3.2"
-# postcard is used only as the byte codec for the blanket `CapabilityEncoding`
-# impl over serde-able capability types; the delegation wire format is hand-rolled
-# on top of bijoux and doesn't use postcard.
+# postcard provides the capability byte codec (the blanket `CapabilityEncoding`
+# impl over serde-able capability types) and the varint encoding of the
+# delegation wire format's numeric fields.
 postcard = { version = "1.1.1", features = ["use-std"] }
 serde = { version = "1.0.217", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,16 @@ repository = "https://github.com/n0-computer/rcan"
 rust-version = "1.91"
 
 [dependencies]
+bijoux = "0.3"
 derive_more = { version = "2.0.1", features = ["debug", "display"] }
 ed25519-dalek = { version = ">=3.0.0-rc.0,<4.0.0", features = ["serde"] }
 data-encoding = "2"
 n0-error = "1"
 hex = "0.4.3"
 n0-future = "0.3.2"
+# postcard is used only as the byte codec for the blanket `CapabilityEncoding`
+# impl over serde-able capability types; the delegation wire format is hand-rolled
+# on top of bijoux and doesn't use postcard.
 postcard = { version = "1.1.1", features = ["use-std"] }
 serde = { version = "1.0.217", features = ["derive"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,21 +595,22 @@ fn encode_body<C: CapabilityEncoding>(delegation: &Delegation<C>, out: &mut Vec<
     out.extend_from_slice(delegation.issuer.as_bytes());
     out.extend_from_slice(delegation.audience.as_bytes());
     match &delegation.capability_origin {
-        CapabilityOrigin::Issuer => bijoux::u64::encode(0, out),
+        // `0u64`/`1u64` as varints
+        CapabilityOrigin::Issuer => out.extend_from_slice(&postcard::to_stdvec(&0u64).unwrap()),
         CapabilityOrigin::Delegation(root) => {
-            bijoux::u64::encode(1, out);
+            out.extend_from_slice(&postcard::to_stdvec(&1u64).unwrap());
             out.extend_from_slice(root.as_bytes());
         }
     }
     match &delegation.valid_until {
-        Expires::Never => bijoux::u64::encode(0, out),
+        Expires::Never => out.extend_from_slice(&postcard::to_stdvec(&0u64).unwrap()),
         Expires::At(t) => {
-            bijoux::u64::encode(1, out);
-            bijoux::u64::encode(*t, out);
+            out.extend_from_slice(&postcard::to_stdvec(&1u64).unwrap());
+            out.extend_from_slice(&postcard::to_stdvec(t).unwrap());
         }
     }
     let capability = C::encode(&delegation.capability);
-    bijoux::u64::encode(capability.len() as u64, out);
+    out.extend_from_slice(&postcard::to_stdvec(&(capability.len() as u64)).unwrap());
     out.extend_from_slice(&capability);
 }
 
@@ -701,8 +702,16 @@ fn take_key(buf: &mut &[u8]) -> Result<VerifyingKey, DecodeError> {
 }
 
 fn take_u64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
-    let (value, consumed) = bijoux::u64::decode(buf)
+    let before = *buf;
+    let (value, rest) = postcard::take_from_bytes::<u64>(buf)
         .map_err(|e| DecodeError::malformed(format!("invalid varint: {e}")))?;
-    *buf = &buf[consumed..];
+    let consumed = &before[..before.len() - rest.len()];
+    // postcard allows overlong varints (e.g. 0 as `0x80 0x00`); the delegation
+    // body requires the canonical encoding, so re-encode and compare.
+    let canonical = postcard::to_stdvec(&value).expect("u64 serializes");
+    if consumed != &canonical[..] {
+        return Err(DecodeError::malformed("non-canonical varint"));
+    }
+    *buf = rest;
     Ok(value)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl Authorizer {
                     authorizer: self.identity,
                 }));
             }
-            if !proof.capability_ref().permits(&capability) {
+            if !proof.capability().permits(&capability) {
                 return Err(e!(InvocationError::NotPermitted));
             }
             current_issuer = proof.audience();
@@ -324,17 +324,12 @@ impl<C> Delegation<C> {
         &self.valid_until
     }
 
-    /// Returns the stored capability, without cloning. Crate-internal; the
-    /// public [`capability`](Self::capability) returns an owned copy.
-    pub(crate) fn capability_ref(&self) -> &C {
+    /// Returns the stored capability by reference.
+    ///
+    /// Borrowing lets an [`OpaqueDelegation`]'s bytes be read without cloning,
+    /// e.g. `delegation.capability().as_bytes()`.
+    pub fn capability(&self) -> &C {
         &self.capability
-    }
-}
-
-impl<C: Clone> Delegation<C> {
-    /// Returns a copy of the stored capability.
-    pub fn capability(&self) -> C {
-        self.capability.clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,11 @@ pub trait Capability: CapabilityEncoding {
 /// expires. Delegations can be chained (see [`CapabilityOrigin`]) so a receiver
 /// can re-delegate an attenuated capability it was given.
 ///
-/// The [`OpaqueDelegation`] form carries the capability as raw bytes and is
-/// turned into a typed `Delegation<C>` with [`parse`](OpaqueDelegation::parse).
+/// Bare `Delegation` (the default `C = OpaqueCapability`) holds the capability
+/// as raw bytes; turn it into a typed `Delegation<C>` with
+/// [`try_into_typed`](Delegation::try_into_typed).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Delegation<C> {
+pub struct Delegation<C = OpaqueCapability> {
     issuer: VerifyingKey,
     audience: VerifyingKey,
     capability_origin: CapabilityOrigin,
@@ -108,10 +109,10 @@ impl<C> Delegation<C> {
 }
 
 impl<C: CapabilityEncoding> Delegation<C> {
-    /// Turns this delegation into an [`OpaqueDelegation`], encoding the
-    /// capability to bytes.
-    pub fn into_opaque(self) -> OpaqueDelegation {
-        OpaqueDelegation::new(
+    /// Turns this delegation into a `Delegation` with an opaque capability,
+    /// encoding the capability to bytes.
+    pub fn into_opaque(self) -> Delegation {
+        Delegation::new(
             self.issuer,
             self.audience,
             self.capability_origin,
@@ -228,8 +229,8 @@ impl<'de, C: CapabilityEncoding> Deserialize<'de> for Delegation<C> {
 
 /// A capability as raw, uninterpreted bytes.
 ///
-/// Used by [`OpaqueDelegation`] to carry a delegation whose capability type is
-/// not (yet) known. Any byte string is a valid `OpaqueCapability`.
+/// This is the default capability type of a [`Delegation`]: a delegation whose
+/// capability is not (yet) known. Any byte string is a valid `OpaqueCapability`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OpaqueCapability(Vec<u8>);
 
@@ -256,13 +257,9 @@ impl Capability for OpaqueCapability {
     }
 }
 
-/// A delegation whose capability is held as raw bytes rather than a typed
-/// value. See [`Delegation`].
-pub type OpaqueDelegation = Delegation<OpaqueCapability>;
-
-impl Delegation<OpaqueCapability> {
-    /// Parses this delegation's capability bytes as a `C`, yielding a typed
-    /// [`Delegation<C>`].
+impl Delegation {
+    /// Consumes this delegation and returns it with the capability interpreted
+    /// as `C`, yielding a typed [`Delegation<C>`].
     ///
     /// # Errors
     ///
@@ -274,7 +271,7 @@ impl Delegation<OpaqueCapability> {
     ///
     /// ```
     /// use ed25519_dalek::SigningKey;
-    /// use rcan::{Delegation, Expires, OpaqueDelegation};
+    /// use rcan::{Delegation, Expires};
     /// use serde::{Deserialize, Serialize};
     ///
     /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -286,9 +283,9 @@ impl Delegation<OpaqueCapability> {
     /// let typed =
     ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
     /// let opaque = typed.into_opaque();
-    /// let back: Delegation<Cap> = opaque.parse().unwrap();
+    /// let back: Delegation<Cap> = opaque.try_into_typed().unwrap();
     /// ```
-    pub fn parse<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
+    pub fn try_into_typed<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
         let capability = C::decode(self.capability.as_bytes())?;
         Ok(Delegation::new(
             self.issuer,
@@ -443,7 +440,8 @@ impl Authorizer {
     /// expiry against an explicit time instead of "now".
     ///
     /// Opaque delegations are not checked directly; parse them into a typed
-    /// delegation with [`OpaqueDelegation::parse`] first, then check them here.
+    /// delegation with [`try_into_typed`](Delegation::try_into_typed) first,
+    /// then check them here.
     pub fn check_invocation_from_at<C: Capability>(
         &self,
         now: SystemTime,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,13 +169,6 @@ fn capability_predicate<C: Capability, T: AsRef<OpaqueDelegation>>(
     }
 }
 
-/// Combines a payload and its signature.
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct Signed {
-    payload: Payload,
-    signature: Signature,
-}
-
 /// A token for attenuated capability delegations.
 ///
 /// An [`OpaqueDelegation`] is guaranteed to be a valid delegation with a valid
@@ -183,7 +176,10 @@ struct Signed {
 ///
 /// The opaque variant keeps the capability as a byte array.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpaqueDelegation(Signed);
+pub struct OpaqueDelegation {
+    payload: Payload,
+    signature: Signature,
+}
 
 impl OpaqueDelegation {
     /// Decodes a v2 delegation from bytes, verifying the signature and canonical encoding.
@@ -199,7 +195,7 @@ impl OpaqueDelegation {
             .issuer
             .verify_strict(&to_verify, &signature)
             .map_err(|_| e!(DecodeError::InvalidSignature))?;
-        Ok(Self(Signed { payload, signature }))
+        Ok(Self { payload, signature })
     }
 
     /// Decodes a delegation from bytes, verifying the signature and canonical encoding.
@@ -220,8 +216,8 @@ impl OpaqueDelegation {
 
     /// Encodes the delegation into bytes, including the version byte.
     pub fn encode(&self) -> Vec<u8> {
-        let mut res = postcard::to_extend(&self.0.payload, vec![2u8]).expect("payload serializes");
-        res.extend_from_slice(&self.0.signature.to_bytes());
+        let mut res = postcard::to_extend(&self.payload, vec![2u8]).expect("payload serializes");
+        res.extend_from_slice(&self.signature.to_bytes());
         res
     }
 
@@ -240,12 +236,12 @@ impl OpaqueDelegation {
 
     /// The payload of the delegation.
     pub fn payload(&self) -> &Payload {
-        &self.0.payload
+        &self.payload
     }
 
     /// The signature of the delegation.
     pub fn signature(&self) -> &Signature {
-        &self.0.signature
+        &self.signature
     }
 
     /// The issuer of the delegation.
@@ -593,7 +589,7 @@ impl<C> DelegationBuilder<'_, C> {
         };
         let to_sign = postcard::to_extend(&payload, DST.to_vec()).expect("payload serializes");
         let signature = self.issuer.sign(&to_sign);
-        Delegation::new(OpaqueDelegation(Signed { payload, signature }))
+        Delegation::new(OpaqueDelegation { payload, signature })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,43 +18,6 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(test)]
 mod tests;
 
-/// The domain-separation tag distinguishing rcan delegations from other
-/// ed25519-signed data. Exposed for applications that re-verify signatures.
-pub const DST: &[u8] = b"rcan-2-delegation";
-
-/// A capability that can be converted to and from its byte representation.
-///
-/// The bytes are what a [`Delegation`] stores and signs. You usually won't
-/// implement this yourself: any [`Serialize`] + [`Deserialize`] type is
-/// supported automatically.
-pub trait CapabilityEncoding {
-    /// Returns the bytes this capability is represented as inside a delegation.
-    fn encode(&self) -> Vec<u8>;
-
-    /// Decodes a capability from its bytes.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`DecodeError::WrongCapability`] if `bytes` is not a valid
-    /// encoding of this capability.
-    fn decode(bytes: &[u8]) -> Result<Self, DecodeError>
-    where
-        Self: Sized;
-}
-
-impl<T: Serialize + DeserializeOwned> CapabilityEncoding for T {
-    fn encode(&self) -> Vec<u8> {
-        postcard::to_stdvec(self).expect("capability serializes")
-    }
-
-    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
-        match postcard::take_from_bytes::<Self>(bytes) {
-            Ok((value, [])) => Ok(value),
-            _ => Err(e!(DecodeError::WrongCapability)),
-        }
-    }
-}
-
 /// A grantable capability.
 ///
 /// Implement this for your own capability type, typically an enum of the
@@ -65,191 +28,6 @@ impl<T: Serialize + DeserializeOwned> CapabilityEncoding for T {
 pub trait Capability: CapabilityEncoding {
     /// Returns `true` if `self` grants the permissions described by `other`.
     fn permits(&self, other: &Self) -> bool;
-}
-
-/// The authority that verifies an invocation.
-///
-/// An [`Authorizer`] holds the public key of the principal that first issued a
-/// capability. `check_invocation_from` verifies that an invocation is backed by
-/// an unexpired, unbroken chain of delegations originating from that principal.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct Authorizer {
-    principal: VerifyingKey,
-}
-
-#[allow(clippy::result_large_err)]
-impl Authorizer {
-    /// Returns an authorizer for the given principal.
-    pub fn new(principal: VerifyingKey) -> Self {
-        Self { principal }
-    }
-
-    /// Verifies an invocation of `capability` by `invoker`, backed by
-    /// `proof_chain`.
-    ///
-    /// The chain must start with the delegation issued by this authorizer's
-    /// principal and end at `invoker`. Make sure the invoker signed and
-    /// authenticated the message carrying `capability`; this method only
-    /// checks the capability chain itself.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ed25519_dalek::SigningKey;
-    /// use rcan::{Authorizer, Capability, Delegation, Expires};
-    /// use serde::{Deserialize, Serialize};
-    ///
-    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-    /// enum Cap {
-    ///     Read,
-    ///     All,
-    /// }
-    /// impl Capability for Cap {
-    ///     fn permits(&self, other: &Self) -> bool {
-    ///         *self == Cap::All || self == other
-    ///     }
-    /// }
-    ///
-    /// let service = SigningKey::from_bytes(&[0u8; 32]);
-    /// let alice = SigningKey::from_bytes(&[1u8; 32]);
-    ///
-    /// let grant = Delegation::issuing_builder(&service, alice.verifying_key(), &Cap::All)
-    ///     .sign(Expires::Never);
-    ///
-    /// let authorizer = Authorizer::new(service.verifying_key());
-    /// authorizer
-    ///     .check_invocation_from(alice.verifying_key(), Cap::Read, &[&grant])
-    ///     .unwrap();
-    /// ```
-    pub fn check_invocation_from<C: Capability>(
-        &self,
-        invoker: VerifyingKey,
-        capability: C,
-        proof_chain: &[&Delegation<C>],
-    ) -> Result<(), InvocationError> {
-        self.check_invocation_from_at(SystemTime::now(), invoker, capability, proof_chain)
-    }
-
-    /// Like [`check_invocation_from`](Self::check_invocation_from), but evaluates
-    /// expiry against an explicit time instead of "now".
-    ///
-    /// Opaque delegations are not checked directly; parse them into a typed
-    /// delegation with [`OpaqueDelegation::parse`] first, then check them here.
-    pub fn check_invocation_from_at<C: Capability>(
-        &self,
-        now: SystemTime,
-        invoker: VerifyingKey,
-        capability: C,
-        proof_chain: &[&Delegation<C>],
-    ) -> Result<(), InvocationError> {
-        // The chain is checked back-to-front: it starts at the owner of the
-        // capability and each delegation names the next issuer.
-        let mut current_issuer = &self.principal;
-        for proof in proof_chain {
-            if proof.issuer() != current_issuer {
-                return Err(e!(InvocationError::ChainBroken {
-                    expected: *current_issuer,
-                    found: *proof.issuer(),
-                }));
-            }
-            if !proof.expires().is_valid_at(now) {
-                return Err(e!(InvocationError::Expired {
-                    expiry: proof.expires().clone(),
-                }));
-            }
-            if proof.capability_owner() != &self.principal {
-                return Err(e!(InvocationError::CapabilityOwnerMismatch {
-                    authorizer: self.principal,
-                }));
-            }
-            if !proof.capability().permits(&capability) {
-                return Err(e!(InvocationError::NotPermitted));
-            }
-            current_issuer = proof.audience();
-        }
-        if &invoker != current_issuer {
-            return Err(e!(InvocationError::InvokerMismatch {
-                invoker,
-                chain_end: *current_issuer,
-            }));
-        }
-        Ok(())
-    }
-}
-
-/// A capability as raw, uninterpreted bytes.
-///
-/// Used by [`OpaqueDelegation`] to carry a delegation whose capability type is
-/// not (yet) known. Any byte string is a valid `OpaqueCapability`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct OpaqueCapability(Vec<u8>);
-
-impl OpaqueCapability {
-    /// Returns the underlying capability bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl CapabilityEncoding for OpaqueCapability {
-    fn encode(&self) -> Vec<u8> {
-        self.0.clone()
-    }
-
-    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
-        Ok(Self(bytes.to_vec()))
-    }
-}
-
-impl Capability for OpaqueCapability {
-    fn permits(&self, other: &Self) -> bool {
-        self == other
-    }
-}
-
-/// A delegation whose capability is held as raw bytes rather than a typed
-/// value. See [`Delegation`].
-pub type OpaqueDelegation = Delegation<OpaqueCapability>;
-
-impl Delegation<OpaqueCapability> {
-    /// Parses this delegation's capability bytes as a `C`, yielding a typed
-    /// [`Delegation<C>`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`DecodeError::WrongCapability`] if the bytes are not a valid
-    /// encoding of `C` (unless `C` is [`OpaqueCapability`], which accepts any
-    /// bytes).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ed25519_dalek::SigningKey;
-    /// use rcan::{Delegation, Expires, OpaqueDelegation};
-    /// use serde::{Deserialize, Serialize};
-    ///
-    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-    /// enum Cap {
-    ///     Read,
-    /// }
-    ///
-    /// let key = SigningKey::from_bytes(&[0u8; 32]);
-    /// let typed =
-    ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
-    /// let opaque = typed.into_opaque();
-    /// let back: Delegation<Cap> = opaque.parse().unwrap();
-    /// ```
-    pub fn parse<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
-        let capability = C::decode(self.capability.as_bytes())?;
-        Ok(Delegation::new(
-            self.issuer,
-            self.audience,
-            self.capability_origin,
-            self.valid_until,
-            capability,
-            self.signature,
-        ))
-    }
 }
 
 /// A signed delegation granting a capability.
@@ -388,38 +166,139 @@ impl<C: CapabilityEncoding> Delegation<C> {
     }
 }
 
-fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C>, DecodeError> {
-    if bytes.len() < SIGNATURE_LENGTH {
-        return Err(DecodeError::malformed("invalid signature length"));
+impl<C: Clone> Delegation<C> {
+    /// Returns a builder for a delegation that `issuer` issues to `audience`
+    /// for `capability`, where `issuer` is the origin of the capability.
+    pub fn issuing_builder<'s>(
+        issuer: &'s SigningKey,
+        audience: VerifyingKey,
+        capability: &C,
+    ) -> DelegationBuilder<'s, C> {
+        DelegationBuilder {
+            issuer,
+            audience,
+            capability_origin: CapabilityOrigin::Issuer,
+            capability: capability.clone(),
+        }
     }
-    let (body_bytes, sig_bytes) = bytes.split_at(bytes.len() - SIGNATURE_LENGTH);
-    let mut body = body_bytes;
-    let delegation = decode_body::<C>(&mut body)?;
-    if !body.is_empty() {
-        return Err(DecodeError::malformed("non canonical encoding of payload"));
+
+    /// Returns a builder for a delegation that `issuer` issues to `audience`
+    /// for `capability`, where the capability was originally held by `owner`.
+    pub fn delegating_builder<'s>(
+        issuer: &'s SigningKey,
+        audience: VerifyingKey,
+        owner: VerifyingKey,
+        capability: &C,
+    ) -> DelegationBuilder<'s, C> {
+        DelegationBuilder {
+            issuer,
+            audience,
+            capability_origin: CapabilityOrigin::Delegation(owner),
+            capability: capability.clone(),
+        }
     }
-    let signature = Signature::from_bytes(
-        sig_bytes
-            .try_into()
-            .map_err(|_| DecodeError::malformed("invalid signature length"))?,
-    );
-    let mut to_verify = DST.to_vec();
-    encode_body::<C>(&delegation, &mut to_verify);
-    if to_verify[DST.len()..] != *body_bytes {
-        return Err(DecodeError::malformed("non canonical encoding of payload"));
+}
+
+/// Serializes the delegation as its byte encoding, or as a base32 string when
+/// the format is human-readable. See [`Delegation::encode`].
+impl<C: CapabilityEncoding> Serialize for Delegation<C> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.encode_string())
+        } else {
+            self.encode().serialize(serializer)
+        }
     }
-    delegation
-        .issuer
-        .verify_strict(&to_verify, &signature)
-        .map_err(|_| e!(DecodeError::InvalidSignature))?;
-    Ok(Delegation::new(
-        delegation.issuer,
-        delegation.audience,
-        delegation.capability_origin,
-        delegation.valid_until,
-        delegation.capability,
-        signature,
-    ))
+}
+
+/// See [`Delegation::decode`], which this forwards to.
+impl<'de, C: CapabilityEncoding> Deserialize<'de> for Delegation<C> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error;
+        let delegation = if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            Self::decode_string(&s)
+        } else {
+            let v = Vec::<u8>::deserialize(deserializer)?;
+            Self::decode(&v)
+        };
+        delegation.map_err(D::Error::custom)
+    }
+}
+
+/// A capability as raw, uninterpreted bytes.
+///
+/// Used by [`OpaqueDelegation`] to carry a delegation whose capability type is
+/// not (yet) known. Any byte string is a valid `OpaqueCapability`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OpaqueCapability(Vec<u8>);
+
+impl OpaqueCapability {
+    /// Returns the underlying capability bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl CapabilityEncoding for OpaqueCapability {
+    fn encode(&self) -> Vec<u8> {
+        self.0.clone()
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        Ok(Self(bytes.to_vec()))
+    }
+}
+
+impl Capability for OpaqueCapability {
+    fn permits(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+/// A delegation whose capability is held as raw bytes rather than a typed
+/// value. See [`Delegation`].
+pub type OpaqueDelegation = Delegation<OpaqueCapability>;
+
+impl Delegation<OpaqueCapability> {
+    /// Parses this delegation's capability bytes as a `C`, yielding a typed
+    /// [`Delegation<C>`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError::WrongCapability`] if the bytes are not a valid
+    /// encoding of `C` (unless `C` is [`OpaqueCapability`], which accepts any
+    /// bytes).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ed25519_dalek::SigningKey;
+    /// use rcan::{Delegation, Expires, OpaqueDelegation};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// enum Cap {
+    ///     Read,
+    /// }
+    ///
+    /// let key = SigningKey::from_bytes(&[0u8; 32]);
+    /// let typed =
+    ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
+    /// let opaque = typed.into_opaque();
+    /// let back: Delegation<Cap> = opaque.parse().unwrap();
+    /// ```
+    pub fn parse<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
+        let capability = C::decode(self.capability.as_bytes())?;
+        Ok(Delegation::new(
+            self.issuer,
+            self.audience,
+            self.capability_origin,
+            self.valid_until,
+            capability,
+            self.signature,
+        ))
+    }
 }
 
 /// Where a delegated capability comes from.
@@ -467,39 +346,6 @@ impl Expires {
     }
 }
 
-impl<C: Clone> Delegation<C> {
-    /// Returns a builder for a delegation that `issuer` issues to `audience`
-    /// for `capability`, where `issuer` is the origin of the capability.
-    pub fn issuing_builder<'s>(
-        issuer: &'s SigningKey,
-        audience: VerifyingKey,
-        capability: &C,
-    ) -> DelegationBuilder<'s, C> {
-        DelegationBuilder {
-            issuer,
-            audience,
-            capability_origin: CapabilityOrigin::Issuer,
-            capability: capability.clone(),
-        }
-    }
-
-    /// Returns a builder for a delegation that `issuer` issues to `audience`
-    /// for `capability`, where the capability was originally held by `owner`.
-    pub fn delegating_builder<'s>(
-        issuer: &'s SigningKey,
-        audience: VerifyingKey,
-        owner: VerifyingKey,
-        capability: &C,
-    ) -> DelegationBuilder<'s, C> {
-        DelegationBuilder {
-            issuer,
-            audience,
-            capability_origin: CapabilityOrigin::Delegation(owner),
-            capability: capability.clone(),
-        }
-    }
-}
-
 /// Builds and signs a [`Delegation`].
 pub struct DelegationBuilder<'s, C> {
     issuer: &'s SigningKey,
@@ -526,6 +372,149 @@ impl<C: CapabilityEncoding + Clone> DelegationBuilder<'_, C> {
         Delegation {
             signature,
             ..delegation
+        }
+    }
+}
+
+/// The authority that verifies an invocation.
+///
+/// An [`Authorizer`] holds the public key of the principal that first issued a
+/// capability. `check_invocation_from` verifies that an invocation is backed by
+/// an unexpired, unbroken chain of delegations originating from that principal.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Authorizer {
+    principal: VerifyingKey,
+}
+
+#[allow(clippy::result_large_err)]
+impl Authorizer {
+    /// Returns an authorizer for the given principal.
+    pub fn new(principal: VerifyingKey) -> Self {
+        Self { principal }
+    }
+
+    /// Verifies an invocation of `capability` by `invoker`, backed by
+    /// `proof_chain`.
+    ///
+    /// The chain must start with the delegation issued by this authorizer's
+    /// principal and end at `invoker`. Make sure the invoker signed and
+    /// authenticated the message carrying `capability`; this method only
+    /// checks the capability chain itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ed25519_dalek::SigningKey;
+    /// use rcan::{Authorizer, Capability, Delegation, Expires};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// enum Cap {
+    ///     Read,
+    ///     All,
+    /// }
+    /// impl Capability for Cap {
+    ///     fn permits(&self, other: &Self) -> bool {
+    ///         *self == Cap::All || self == other
+    ///     }
+    /// }
+    ///
+    /// let service = SigningKey::from_bytes(&[0u8; 32]);
+    /// let alice = SigningKey::from_bytes(&[1u8; 32]);
+    ///
+    /// let grant = Delegation::issuing_builder(&service, alice.verifying_key(), &Cap::All)
+    ///     .sign(Expires::Never);
+    ///
+    /// let authorizer = Authorizer::new(service.verifying_key());
+    /// authorizer
+    ///     .check_invocation_from(alice.verifying_key(), Cap::Read, &[&grant])
+    ///     .unwrap();
+    /// ```
+    pub fn check_invocation_from<C: Capability>(
+        &self,
+        invoker: VerifyingKey,
+        capability: C,
+        proof_chain: &[&Delegation<C>],
+    ) -> Result<(), InvocationError> {
+        self.check_invocation_from_at(SystemTime::now(), invoker, capability, proof_chain)
+    }
+
+    /// Like [`check_invocation_from`](Self::check_invocation_from), but evaluates
+    /// expiry against an explicit time instead of "now".
+    ///
+    /// Opaque delegations are not checked directly; parse them into a typed
+    /// delegation with [`OpaqueDelegation::parse`] first, then check them here.
+    pub fn check_invocation_from_at<C: Capability>(
+        &self,
+        now: SystemTime,
+        invoker: VerifyingKey,
+        capability: C,
+        proof_chain: &[&Delegation<C>],
+    ) -> Result<(), InvocationError> {
+        // The chain is checked back-to-front: it starts at the owner of the
+        // capability and each delegation names the next issuer.
+        let mut current_issuer = &self.principal;
+        for proof in proof_chain {
+            if proof.issuer() != current_issuer {
+                return Err(e!(InvocationError::ChainBroken {
+                    expected: *current_issuer,
+                    found: *proof.issuer(),
+                }));
+            }
+            if !proof.expires().is_valid_at(now) {
+                return Err(e!(InvocationError::Expired {
+                    expiry: proof.expires().clone(),
+                }));
+            }
+            if proof.capability_owner() != &self.principal {
+                return Err(e!(InvocationError::CapabilityOwnerMismatch {
+                    authorizer: self.principal,
+                }));
+            }
+            if !proof.capability().permits(&capability) {
+                return Err(e!(InvocationError::NotPermitted));
+            }
+            current_issuer = proof.audience();
+        }
+        if &invoker != current_issuer {
+            return Err(e!(InvocationError::InvokerMismatch {
+                invoker,
+                chain_end: *current_issuer,
+            }));
+        }
+        Ok(())
+    }
+}
+
+/// A capability that can be converted to and from its byte representation.
+///
+/// The bytes are what a [`Delegation`] stores and signs. You usually won't
+/// implement this yourself: any [`Serialize`] + [`Deserialize`] type is
+/// supported automatically.
+pub trait CapabilityEncoding {
+    /// Returns the bytes this capability is represented as inside a delegation.
+    fn encode(&self) -> Vec<u8>;
+
+    /// Decodes a capability from its bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError::WrongCapability`] if `bytes` is not a valid
+    /// encoding of this capability.
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError>
+    where
+        Self: Sized;
+}
+
+impl<T: Serialize + DeserializeOwned> CapabilityEncoding for T {
+    fn encode(&self) -> Vec<u8> {
+        postcard::to_stdvec(self).expect("capability serializes")
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        match postcard::take_from_bytes::<Self>(bytes) {
+            Ok((value, [])) => Ok(value),
+            _ => Err(e!(DecodeError::WrongCapability)),
         }
     }
 }
@@ -596,35 +585,14 @@ pub enum InvocationError {
     },
 }
 
-/// Serializes the delegation as its byte encoding, or as a base32 string when
-/// the format is human-readable. See [`Delegation::encode`].
-impl<C: CapabilityEncoding> Serialize for Delegation<C> {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        if serializer.is_human_readable() {
-            serializer.serialize_str(&self.encode_string())
-        } else {
-            self.encode().serialize(serializer)
-        }
-    }
-}
+/// The domain-separation tag distinguishing rcan delegations from other
+/// ed25519-signed data. Exposed for applications that re-verify signatures.
+pub const DST: &[u8] = b"rcan-2-delegation";
 
-/// See [`Delegation::decode`], which this forwards to.
-impl<'de, C: CapabilityEncoding> Deserialize<'de> for Delegation<C> {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use serde::de::Error;
-        let delegation = if deserializer.is_human_readable() {
-            let s = String::deserialize(deserializer)?;
-            Self::decode_string(&s)
-        } else {
-            let v = Vec::<u8>::deserialize(deserializer)?;
-            Self::decode(&v)
-        };
-        delegation.map_err(D::Error::custom)
-    }
-}
+pub(crate) const BASE32_LOWER_NOPAD: data_encoding::Encoding = data_encoding_macro::new_encoding!(
+    symbols: "abcdefghijklmnopqrstuvwxyz234567",
+);
 
-/// Encodes a delegation's payload (everything except its signature) into the
-/// canonical byte representation that gets signed.
 fn encode_body<C: CapabilityEncoding>(delegation: &Delegation<C>, out: &mut Vec<u8>) {
     out.extend_from_slice(delegation.issuer.as_bytes());
     out.extend_from_slice(delegation.audience.as_bytes());
@@ -647,32 +615,38 @@ fn encode_body<C: CapabilityEncoding>(delegation: &Delegation<C>, out: &mut Vec<
     out.extend_from_slice(&capability);
 }
 
-fn take_bytes<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], DecodeError> {
-    let (head, rest) = buf
-        .split_at_checked(n)
-        .ok_or_else(|| DecodeError::malformed("payload is truncated"))?;
-    *buf = rest;
-    Ok(head)
-}
-
-fn take_chunk<'a, const N: usize>(buf: &mut &'a [u8]) -> Result<&'a [u8; N], DecodeError> {
-    let Some((head, rest)) = buf.split_first_chunk() else {
-        return Err(DecodeError::malformed("payload is truncated"));
-    };
-    *buf = rest;
-    Ok(head)
-}
-
-fn take_key(buf: &mut &[u8]) -> Result<VerifyingKey, DecodeError> {
-    let bytes = take_chunk::<32>(buf)?;
-    VerifyingKey::from_bytes(bytes).map_err(|_| DecodeError::malformed("invalid key"))
-}
-
-fn take_u64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
-    let (value, consumed) = bijoux::u64::decode(buf)
-        .map_err(|e| DecodeError::malformed(format!("invalid varint: {e}")))?;
-    *buf = &buf[consumed..];
-    Ok(value)
+fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C>, DecodeError> {
+    if bytes.len() < SIGNATURE_LENGTH {
+        return Err(DecodeError::malformed("invalid signature length"));
+    }
+    let (body_bytes, sig_bytes) = bytes.split_at(bytes.len() - SIGNATURE_LENGTH);
+    let mut body = body_bytes;
+    let delegation = decode_body::<C>(&mut body)?;
+    if !body.is_empty() {
+        return Err(DecodeError::malformed("non canonical encoding of payload"));
+    }
+    let signature = Signature::from_bytes(
+        sig_bytes
+            .try_into()
+            .map_err(|_| DecodeError::malformed("invalid signature length"))?,
+    );
+    let mut to_verify = DST.to_vec();
+    encode_body::<C>(&delegation, &mut to_verify);
+    if to_verify[DST.len()..] != *body_bytes {
+        return Err(DecodeError::malformed("non canonical encoding of payload"));
+    }
+    delegation
+        .issuer
+        .verify_strict(&to_verify, &signature)
+        .map_err(|_| e!(DecodeError::InvalidSignature))?;
+    Ok(Delegation::new(
+        delegation.issuer,
+        delegation.audience,
+        delegation.capability_origin,
+        delegation.valid_until,
+        delegation.capability,
+        signature,
+    ))
 }
 
 fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, DecodeError> {
@@ -707,6 +681,30 @@ fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, 
     ))
 }
 
-pub(crate) const BASE32_LOWER_NOPAD: data_encoding::Encoding = data_encoding_macro::new_encoding!(
-    symbols: "abcdefghijklmnopqrstuvwxyz234567",
-);
+fn take_bytes<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], DecodeError> {
+    let (head, rest) = buf
+        .split_at_checked(n)
+        .ok_or_else(|| DecodeError::malformed("payload is truncated"))?;
+    *buf = rest;
+    Ok(head)
+}
+
+fn take_chunk<'a, const N: usize>(buf: &mut &'a [u8]) -> Result<&'a [u8; N], DecodeError> {
+    let Some((head, rest)) = buf.split_first_chunk() else {
+        return Err(DecodeError::malformed("payload is truncated"));
+    };
+    *buf = rest;
+    Ok(head)
+}
+
+fn take_key(buf: &mut &[u8]) -> Result<VerifyingKey, DecodeError> {
+    let bytes = take_chunk::<32>(buf)?;
+    VerifyingKey::from_bytes(bytes).map_err(|_| DecodeError::malformed("invalid key"))
+}
+
+fn take_u64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
+    let (value, consumed) = bijoux::u64::decode(buf)
+        .map_err(|e| DecodeError::malformed(format!("invalid varint: {e}")))?;
+    *buf = &buf[consumed..];
+    Ok(value)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,9 +354,7 @@ impl<C: CapabilityEncoding> Delegation<C> {
     /// Returns a lowercase base32 string of the delegation's byte encoding,
     /// useful for compact, printable representations.
     pub fn encode_string(&self) -> String {
-        let mut out = data_encoding::BASE32_NOPAD.encode(&self.encode());
-        out.make_ascii_lowercase();
-        out
+        BASE32_LOWER_NOPAD.encode(&self.encode())
     }
 
     /// Decodes a delegation from its byte encoding, verifying the signature and
@@ -383,7 +381,10 @@ impl<C: CapabilityEncoding> Delegation<C> {
     /// Decodes a delegation from a base32 string, verifying the signature and
     /// decoding the capability as `C`. See [`decode`](Delegation::decode).
     pub fn decode_string(s: &str) -> Result<Self, DecodeError> {
-        Self::decode(&base32_bytes(s)?)
+        let bytes = BASE32_LOWER_NOPAD
+            .decode(s.as_bytes())
+            .map_err(DecodeError::malformed)?;
+        Self::decode(&bytes)
     }
 }
 
@@ -706,8 +707,6 @@ fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, 
     ))
 }
 
-fn base32_bytes(s: &str) -> Result<Vec<u8>, DecodeError> {
-    data_encoding::BASE32_NOPAD
-        .decode(s.to_ascii_uppercase().as_bytes())
-        .map_err(DecodeError::malformed)
-}
+pub(crate) const BASE32_LOWER_NOPAD: data_encoding::Encoding = data_encoding_macro::new_encoding!(
+    symbols: "abcdefghijklmnopqrstuvwxyz234567",
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,26 +69,26 @@ pub trait Capability: CapabilityEncoding {
 
 /// The authority that verifies an invocation.
 ///
-/// An [`Authorizer`] holds the public key of the identity that first issued a
+/// An [`Authorizer`] holds the public key of the principal that first issued a
 /// capability. `check_invocation_from` verifies that an invocation is backed by
-/// an unexpired, unbroken chain of delegations originating from that identity.
+/// an unexpired, unbroken chain of delegations originating from that principal.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Authorizer {
-    identity: VerifyingKey,
+    principal: VerifyingKey,
 }
 
 #[allow(clippy::result_large_err)]
 impl Authorizer {
-    /// Returns an authorizer for the given verifying key.
-    pub fn new(identity: VerifyingKey) -> Self {
-        Self { identity }
+    /// Returns an authorizer for the given principal.
+    pub fn new(principal: VerifyingKey) -> Self {
+        Self { principal }
     }
 
     /// Verifies an invocation of `capability` by `invoker`, backed by
     /// `proof_chain`.
     ///
     /// The chain must start with the delegation issued by this authorizer's
-    /// identity and end at `invoker`. Make sure the invoker signed and
+    /// principal and end at `invoker`. Make sure the invoker signed and
     /// authenticated the message carrying `capability`; this method only
     /// checks the capability chain itself.
     ///
@@ -144,7 +144,7 @@ impl Authorizer {
     ) -> Result<(), InvocationError> {
         // The chain is checked back-to-front: it starts at the owner of the
         // capability and each delegation names the next issuer.
-        let mut current_issuer = &self.identity;
+        let mut current_issuer = &self.principal;
         for proof in proof_chain {
             if proof.issuer() != current_issuer {
                 return Err(e!(InvocationError::ChainBroken {
@@ -157,9 +157,9 @@ impl Authorizer {
                     expiry: proof.expires().clone(),
                 }));
             }
-            if proof.capability_owner() != &self.identity {
-                return Err(e!(InvocationError::WrongCapabilityOwner {
-                    authorizer: self.identity,
+            if proof.capability_owner() != &self.principal {
+                return Err(e!(InvocationError::CapabilityOwnerMismatch {
+                    authorizer: self.principal,
                 }));
             }
             if !proof.capability().permits(&capability) {
@@ -168,7 +168,7 @@ impl Authorizer {
             current_issuer = proof.audience();
         }
         if &invoker != current_issuer {
-            return Err(e!(InvocationError::WrongInvoker {
+            return Err(e!(InvocationError::InvokerMismatch {
                 invoker,
                 chain_end: *current_issuer,
             }));
@@ -296,12 +296,12 @@ impl<C> Delegation<C> {
         &self.signature
     }
 
-    /// Returns the issuing identity.
+    /// Returns the public key of the issuing principal.
     pub fn issuer(&self) -> &VerifyingKey {
         &self.issuer
     }
 
-    /// Returns the identity this delegation was granted to.
+    /// Returns the public key of the principal this delegation was granted to.
     pub fn audience(&self) -> &VerifyingKey {
         &self.audience
     }
@@ -311,7 +311,7 @@ impl<C> Delegation<C> {
         &self.capability_origin
     }
 
-    /// Returns the identity that owns the capability.
+    /// Returns the public key of the principal that owns the capability.
     pub fn capability_owner(&self) -> &VerifyingKey {
         match &self.capability_origin {
             CapabilityOrigin::Issuer => &self.issuer,
@@ -325,9 +325,6 @@ impl<C> Delegation<C> {
     }
 
     /// Returns the stored capability by reference.
-    ///
-    /// Borrowing lets an [`OpaqueDelegation`]'s bytes be read without cloning,
-    /// e.g. `delegation.capability().as_bytes()`.
     pub fn capability(&self) -> &C {
         &self.capability
     }
@@ -429,9 +426,9 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
 /// Where a delegated capability comes from.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CapabilityOrigin {
-    /// The capability originates with the delegating identity itself.
+    /// The capability originates with the delegating principal itself.
     Issuer,
-    /// The capability was previously granted by this root identity.
+    /// The capability was previously granted by this root principal.
     Delegation(VerifyingKey),
 }
 
@@ -541,8 +538,9 @@ pub enum DecodeError {
     /// The input is malformed, with a reason.
     #[error("malformed token: {reason}")]
     Malformed { reason: String },
-    /// The input is a version-1 (legacy) token; use rcan 0.4.x to read those.
-    #[error("v1 tokens are not supported, use rcan 0.4.x to read them")]
+    /// The input is a legacy version-1 token, which this crate does not read.
+    /// Re-encode it with an older rcan client first.
+    #[error("rcan delegation version 1 not supported")]
     UnsupportedV1,
     /// The token's signature is invalid.
     #[error("signature verification failed")]
@@ -566,7 +564,7 @@ impl DecodeError {
 #[non_exhaustive]
 pub enum InvocationError {
     /// The proof chain is broken: a delegation was issued by a different
-    /// identity than the previous delegation was granted to.
+    /// principal than the previous delegation was granted to.
     #[error(
         "expected proof to be issued by {}, but was issued by {}",
         hex::encode(expected),
@@ -583,8 +581,8 @@ pub enum InvocationError {
         "proof is missing delegation for capability of {}",
         hex::encode(authorizer)
     )]
-    /// A delegation in the chain does not convey the authorizer's capability.
-    WrongCapabilityOwner { authorizer: VerifyingKey },
+    /// A delegation in the chain delegates a capability from a different owner.
+    CapabilityOwnerMismatch { authorizer: VerifyingKey },
     /// No delegation in the chain permits the requested capability.
     #[error("capability not permitted")]
     NotPermitted,
@@ -594,7 +592,7 @@ pub enum InvocationError {
         hex::encode(chain_end)
     )]
     /// The final audience in the chain does not match the invoker.
-    WrongInvoker {
+    InvokerMismatch {
         invoker: VerifyingKey,
         chain_end: VerifyingKey,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,6 @@ pub struct Delegation<C> {
 }
 
 impl<C> Delegation<C> {
-    /// Constructs a new delegation from its parts.
     fn new(
         issuer: VerifyingKey,
         audience: VerifyingKey,
@@ -388,15 +387,14 @@ impl<C: CapabilityEncoding> Delegation<C> {
     }
 }
 
-/// Decodes a v2 delegation, verifying the signature and canonical encoding and
-/// that the capability decodes as `C`.
 fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C>, DecodeError> {
     if bytes.len() < SIGNATURE_LENGTH {
         return Err(DecodeError::malformed("invalid signature length"));
     }
     let (body_bytes, sig_bytes) = bytes.split_at(bytes.len() - SIGNATURE_LENGTH);
-    let (delegation, used) = decode_body::<C>(body_bytes)?;
-    if used != body_bytes.len() {
+    let mut body = body_bytes;
+    let delegation = decode_body::<C>(&mut body)?;
+    if !body.is_empty() {
         return Err(DecodeError::malformed("non canonical encoding of payload"));
     }
     let signature = Signature::from_bytes(
@@ -551,7 +549,6 @@ pub enum DecodeError {
 }
 
 impl DecodeError {
-    /// Returns a `Malformed` error for the given `reason`.
     fn malformed(reason: impl std::fmt::Display) -> Self {
         e!(DecodeError::Malformed {
             reason: reason.to_string()
@@ -649,75 +646,66 @@ fn encode_body<C: CapabilityEncoding>(delegation: &Delegation<C>, out: &mut Vec<
     out.extend_from_slice(&capability);
 }
 
-/// Decodes a delegation's payload from its canonical byte representation,
-/// returning it along with the number of bytes consumed. The capability is
-/// decoded as `C`, and the signature field is left empty.
-fn decode_body<C: CapabilityEncoding>(bytes: &[u8]) -> Result<(Delegation<C>, usize), DecodeError> {
-    let mut cursor = 0usize;
-    macro_rules! take {
-        ($n:expr) => {{
-            let end = cursor
-                .checked_add($n)
-                .ok_or_else(|| DecodeError::malformed("payload length overflow"))?;
-            let slice = bytes
-                .get(cursor..end)
-                .ok_or_else(|| DecodeError::malformed("payload is truncated"))?;
-            cursor = end;
-            slice
-        }};
-    }
-    macro_rules! take_u64 {
-        () => {{
-            let (value, consumed) = bijoux::u64::decode(&bytes[cursor..])
-                .map_err(|e| DecodeError::malformed(format!("invalid varint: {e}")))?;
-            cursor += consumed;
-            value
-        }};
-    }
+fn take_bytes<'a>(buf: &mut &'a [u8], n: usize) -> Result<&'a [u8], DecodeError> {
+    let (head, rest) = buf
+        .split_at_checked(n)
+        .ok_or_else(|| DecodeError::malformed("payload is truncated"))?;
+    *buf = rest;
+    Ok(head)
+}
 
-    let issuer = VerifyingKey::from_bytes(take!(32).try_into().expect("32 bytes"))
-        .map_err(|_| DecodeError::malformed("invalid issuer"))?;
-    let audience = VerifyingKey::from_bytes(take!(32).try_into().expect("32 bytes"))
-        .map_err(|_| DecodeError::malformed("invalid audience"))?;
-    let capability_origin = match take_u64!() {
+fn take_chunk<'a, const N: usize>(buf: &mut &'a [u8]) -> Result<&'a [u8; N], DecodeError> {
+    let Some((head, rest)) = buf.split_first_chunk() else {
+        return Err(DecodeError::malformed("payload is truncated"));
+    };
+    *buf = rest;
+    Ok(head)
+}
+
+fn take_key(buf: &mut &[u8]) -> Result<VerifyingKey, DecodeError> {
+    let bytes = take_chunk::<32>(buf)?;
+    VerifyingKey::from_bytes(bytes).map_err(|_| DecodeError::malformed("invalid key"))
+}
+
+fn take_u64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
+    let (value, consumed) = bijoux::u64::decode(buf)
+        .map_err(|e| DecodeError::malformed(format!("invalid varint: {e}")))?;
+    *buf = &buf[consumed..];
+    Ok(value)
+}
+
+fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, DecodeError> {
+    let issuer = take_key(buf)?;
+    let audience = take_key(buf)?;
+    let capability_origin = match take_u64(buf)? {
         0 => CapabilityOrigin::Issuer,
-        1 => {
-            let root = VerifyingKey::from_bytes(take!(32).try_into().expect("32 bytes"))
-                .map_err(|_| DecodeError::malformed("invalid capability origin"))?;
-            CapabilityOrigin::Delegation(root)
-        }
+        1 => CapabilityOrigin::Delegation(take_key(buf)?),
         tag => {
             return Err(DecodeError::malformed(format!(
                 "unknown capability origin tag {tag}"
             )))
         }
     };
-    let valid_until = match take_u64!() {
+    let valid_until = match take_u64(buf)? {
         0 => Expires::Never,
-        1 => Expires::At(take_u64!()),
+        1 => Expires::At(take_u64(buf)?),
         tag => return Err(DecodeError::malformed(format!("unknown expires tag {tag}"))),
     };
-    let cap_len = usize::try_from(take_u64!())
+    let cap_len = usize::try_from(take_u64(buf)?)
         .map_err(|_| DecodeError::malformed("capability length overflow"))?;
-    let cap_bytes = take!(cap_len);
+    let cap_bytes = take_bytes(buf, cap_len)?;
     let capability = C::decode(cap_bytes)?;
 
-    Ok((
-        Delegation::new(
-            issuer,
-            audience,
-            capability_origin,
-            valid_until,
-            capability,
-            Signature::from_bytes(&[0u8; 64]),
-        ),
-        cursor,
+    Ok(Delegation::new(
+        issuer,
+        audience,
+        capability_origin,
+        valid_until,
+        capability,
+        Signature::from_bytes(&[0u8; 64]),
     ))
 }
 
-/// Decodes a string as case insensitive base32, returning the bytes.
-///
-/// If the string is not valid base32, returns a [`DecodeError::Malformed`] error.
 fn base32_bytes(s: &str) -> Result<Vec<u8>, DecodeError> {
     data_encoding::BASE32_NOPAD
         .decode(s.to_ascii_uppercase().as_bytes())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl<C: CapabilityEncoding> Serialize for Delegation<C> {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.encode_string())
         } else {
-            self.encode().serialize(serializer)
+            serializer.serialize_bytes(&self.encode())
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,12 +157,12 @@ impl Authorizer {
                     expiry: proof.expires().clone(),
                 }));
             }
-            if proof.capability_issuer() != &self.identity {
-                return Err(e!(InvocationError::WrongCapabilityIssuer {
+            if proof.capability_owner() != &self.identity {
+                return Err(e!(InvocationError::WrongCapabilityOwner {
                     authorizer: self.identity,
                 }));
             }
-            if !proof.payload().capability().permits(&capability) {
+            if !proof.capability_ref().permits(&capability) {
                 return Err(e!(InvocationError::NotPermitted));
             }
             current_issuer = proof.audience();
@@ -240,15 +240,13 @@ impl Delegation<OpaqueCapability> {
     /// let back: Delegation<Cap> = opaque.parse().unwrap();
     /// ```
     pub fn parse<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
-        let capability = C::decode(self.payload.capability.as_bytes())?;
+        let capability = C::decode(self.capability.as_bytes())?;
         Ok(Delegation::new(
-            Payload {
-                issuer: self.payload.issuer,
-                audience: self.payload.audience,
-                capability_origin: self.payload.capability_origin,
-                valid_until: self.payload.valid_until,
-                capability,
-            },
+            self.issuer,
+            self.audience,
+            self.capability_origin,
+            self.valid_until,
+            capability,
             self.signature,
         ))
     }
@@ -265,19 +263,32 @@ impl Delegation<OpaqueCapability> {
 /// turned into a typed `Delegation<C>` with [`parse`](OpaqueDelegation::parse).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Delegation<C> {
-    payload: Payload<C>,
+    issuer: VerifyingKey,
+    audience: VerifyingKey,
+    capability_origin: CapabilityOrigin,
+    valid_until: Expires,
+    capability: C,
     signature: Signature,
 }
 
 impl<C> Delegation<C> {
-    /// Constructs a new delegation from a payload and signature.
-    fn new(payload: Payload<C>, signature: Signature) -> Self {
-        Self { payload, signature }
-    }
-
-    /// Returns the delegation's payload.
-    pub fn payload(&self) -> &Payload<C> {
-        &self.payload
+    /// Constructs a new delegation from its parts.
+    fn new(
+        issuer: VerifyingKey,
+        audience: VerifyingKey,
+        capability_origin: CapabilityOrigin,
+        valid_until: Expires,
+        capability: C,
+        signature: Signature,
+    ) -> Self {
+        Self {
+            issuer,
+            audience,
+            capability_origin,
+            valid_until,
+            capability,
+            signature,
+        }
     }
 
     /// Returns the delegation's signature.
@@ -287,34 +298,43 @@ impl<C> Delegation<C> {
 
     /// Returns the issuing identity.
     pub fn issuer(&self) -> &VerifyingKey {
-        self.payload.issuer()
+        &self.issuer
     }
 
     /// Returns the identity this delegation was granted to.
     pub fn audience(&self) -> &VerifyingKey {
-        self.payload.audience()
+        &self.audience
     }
 
     /// Returns the origin of the delegated capability.
     pub fn capability_origin(&self) -> &CapabilityOrigin {
-        self.payload.capability_origin()
+        &self.capability_origin
     }
 
-    /// Returns the identity that originally held the capability.
-    pub fn capability_issuer(&self) -> &VerifyingKey {
-        self.payload.capability_issuer()
+    /// Returns the identity that owns the capability.
+    pub fn capability_owner(&self) -> &VerifyingKey {
+        match &self.capability_origin {
+            CapabilityOrigin::Issuer => &self.issuer,
+            CapabilityOrigin::Delegation(root) => root,
+        }
     }
 
     /// Returns when this delegation expires.
     pub fn expires(&self) -> &Expires {
-        self.payload.expires()
+        &self.valid_until
+    }
+
+    /// Returns the stored capability, without cloning. Crate-internal; the
+    /// public [`capability`](Self::capability) returns an owned copy.
+    pub(crate) fn capability_ref(&self) -> &C {
+        &self.capability
     }
 }
 
 impl<C: Clone> Delegation<C> {
     /// Returns a copy of the stored capability.
     pub fn capability(&self) -> C {
-        self.payload.capability().clone()
+        self.capability.clone()
     }
 }
 
@@ -322,15 +342,12 @@ impl<C: CapabilityEncoding> Delegation<C> {
     /// Turns this delegation into an [`OpaqueDelegation`], encoding the
     /// capability to bytes.
     pub fn into_opaque(self) -> OpaqueDelegation {
-        let encoded = C::encode(&self.payload.capability);
         OpaqueDelegation::new(
-            Payload {
-                issuer: self.payload.issuer,
-                audience: self.payload.audience,
-                capability_origin: self.payload.capability_origin,
-                valid_until: self.payload.valid_until,
-                capability: OpaqueCapability(encoded),
-            },
+            self.issuer,
+            self.audience,
+            self.capability_origin,
+            self.valid_until,
+            OpaqueCapability(C::encode(&self.capability)),
             self.signature,
         )
     }
@@ -338,7 +355,7 @@ impl<C: CapabilityEncoding> Delegation<C> {
     /// Returns the delegation's byte encoding.
     pub fn encode(&self) -> Vec<u8> {
         let mut res = vec![2u8];
-        encode_payload(&self.payload, &mut res);
+        encode_body(self, &mut res);
         res.extend_from_slice(&self.signature.to_bytes());
         res
     }
@@ -385,9 +402,9 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
     if bytes.len() < SIGNATURE_LENGTH {
         return Err(DecodeError::malformed("invalid signature length"));
     }
-    let (payload_bytes, sig_bytes) = bytes.split_at(bytes.len() - SIGNATURE_LENGTH);
-    let (payload, used) = decode_payload::<C>(payload_bytes)?;
-    if used != payload_bytes.len() {
+    let (body_bytes, sig_bytes) = bytes.split_at(bytes.len() - SIGNATURE_LENGTH);
+    let (delegation, used) = decode_body::<C>(body_bytes)?;
+    if used != body_bytes.len() {
         return Err(DecodeError::malformed("non canonical encoding of payload"));
     }
     let signature = Signature::from_bytes(
@@ -396,66 +413,22 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
             .map_err(|_| DecodeError::malformed("invalid signature length"))?,
     );
     let mut to_verify = DST.to_vec();
-    encode_payload::<C>(&payload, &mut to_verify);
-    if to_verify[DST.len()..] != *payload_bytes {
+    encode_body::<C>(&delegation, &mut to_verify);
+    if to_verify[DST.len()..] != *body_bytes {
         return Err(DecodeError::malformed("non canonical encoding of payload"));
     }
-    payload
+    delegation
         .issuer
         .verify_strict(&to_verify, &signature)
         .map_err(|_| e!(DecodeError::InvalidSignature))?;
-    Ok(Delegation::new(payload, signature))
-}
-
-/// The signed contents of a [`Delegation`]: the parties, the capability, and
-/// its expiry. Prefer the accessors on [`Delegation`] over this type directly.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Payload<C> {
-    /// The issuing identity
-    issuer: VerifyingKey,
-    /// The intended audience
-    audience: VerifyingKey,
-    /// The origin of the capability
-    capability_origin: CapabilityOrigin,
-    /// When the delegation expires
-    valid_until: Expires,
-    /// The capability
-    capability: C,
-}
-
-impl<C> Payload<C> {
-    /// Returns the issuing identity.
-    pub fn issuer(&self) -> &VerifyingKey {
-        &self.issuer
-    }
-
-    /// Returns the identity this delegation was granted to.
-    pub fn audience(&self) -> &VerifyingKey {
-        &self.audience
-    }
-
-    /// Returns the origin of the delegated capability.
-    pub fn capability_origin(&self) -> &CapabilityOrigin {
-        &self.capability_origin
-    }
-
-    /// Returns the identity that originally held the capability.
-    pub fn capability_issuer(&self) -> &VerifyingKey {
-        match &self.capability_origin {
-            CapabilityOrigin::Issuer => &self.issuer,
-            CapabilityOrigin::Delegation(root) => root,
-        }
-    }
-
-    /// Returns when this payload expires.
-    pub fn expires(&self) -> &Expires {
-        &self.valid_until
-    }
-
-    /// Returns the capability.
-    pub fn capability(&self) -> &C {
-        &self.capability
-    }
+    Ok(Delegation::new(
+        delegation.issuer,
+        delegation.audience,
+        delegation.capability_origin,
+        delegation.valid_until,
+        delegation.capability,
+        signature,
+    ))
 }
 
 /// Where a delegated capability comes from.
@@ -548,17 +521,21 @@ impl<C: CapabilityEncoding + Clone> DelegationBuilder<'_, C> {
     /// Signs the delegation, returning a [`Delegation<C>`] valid until
     /// `valid_until`.
     pub fn sign(self, valid_until: Expires) -> Delegation<C> {
-        let payload = Payload {
-            issuer: self.issuer.verifying_key(),
-            audience: self.audience,
-            capability_origin: self.capability_origin,
+        let delegation = Delegation::new(
+            self.issuer.verifying_key(),
+            self.audience,
+            self.capability_origin,
             valid_until,
-            capability: self.capability,
-        };
+            self.capability,
+            Signature::from_bytes(&[0u8; 64]),
+        );
         let mut to_sign = DST.to_vec();
-        encode_payload(&payload, &mut to_sign);
+        encode_body(&delegation, &mut to_sign);
         let signature = self.issuer.sign(&to_sign);
-        Delegation::new(payload, signature)
+        Delegation {
+            signature,
+            ..delegation
+        }
     }
 }
 
@@ -612,7 +589,7 @@ pub enum InvocationError {
         hex::encode(authorizer)
     )]
     /// A delegation in the chain does not convey the authorizer's capability.
-    WrongCapabilityIssuer { authorizer: VerifyingKey },
+    WrongCapabilityOwner { authorizer: VerifyingKey },
     /// No delegation in the chain permits the requested capability.
     #[error("capability not permitted")]
     NotPermitted,
@@ -655,33 +632,34 @@ impl<'de, C: CapabilityEncoding> Deserialize<'de> for Delegation<C> {
     }
 }
 
-/// Encodes the payload into its canonical byte representation (the part of the
-/// wire format that gets signed, without the leading version byte).
-fn encode_payload<C: CapabilityEncoding>(payload: &Payload<C>, out: &mut Vec<u8>) {
-    out.extend_from_slice(payload.issuer.as_bytes());
-    out.extend_from_slice(payload.audience.as_bytes());
-    match &payload.capability_origin {
+/// Encodes a delegation's payload (everything except its signature) into the
+/// canonical byte representation that gets signed.
+fn encode_body<C: CapabilityEncoding>(delegation: &Delegation<C>, out: &mut Vec<u8>) {
+    out.extend_from_slice(delegation.issuer.as_bytes());
+    out.extend_from_slice(delegation.audience.as_bytes());
+    match &delegation.capability_origin {
         CapabilityOrigin::Issuer => bijoux::u64::encode(0, out),
         CapabilityOrigin::Delegation(root) => {
             bijoux::u64::encode(1, out);
             out.extend_from_slice(root.as_bytes());
         }
     }
-    match &payload.valid_until {
+    match &delegation.valid_until {
         Expires::Never => bijoux::u64::encode(0, out),
         Expires::At(t) => {
             bijoux::u64::encode(1, out);
             bijoux::u64::encode(*t, out);
         }
     }
-    let capability = C::encode(&payload.capability);
+    let capability = C::encode(&delegation.capability);
     bijoux::u64::encode(capability.len() as u64, out);
     out.extend_from_slice(&capability);
 }
 
-/// Decodes a payload from its canonical byte representation, returning it along
-/// with the number of bytes consumed. The capability is decoded as `C`.
-fn decode_payload<C: CapabilityEncoding>(bytes: &[u8]) -> Result<(Payload<C>, usize), DecodeError> {
+/// Decodes a delegation's payload from its canonical byte representation,
+/// returning it along with the number of bytes consumed. The capability is
+/// decoded as `C`, and the signature field is left empty.
+fn decode_body<C: CapabilityEncoding>(bytes: &[u8]) -> Result<(Delegation<C>, usize), DecodeError> {
     let mut cursor = 0usize;
     macro_rules! take {
         ($n:expr) => {{
@@ -732,13 +710,14 @@ fn decode_payload<C: CapabilityEncoding>(bytes: &[u8]) -> Result<(Payload<C>, us
     let capability = C::decode(cap_bytes)?;
 
     Ok((
-        Payload {
+        Delegation::new(
             issuer,
             audience,
             capability_origin,
             valid_until,
             capability,
-        },
+            Signature::from_bytes(&[0u8; 64]),
+        ),
         cursor,
     ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,40 +1,77 @@
+//! Capability-based authorization through signed delegations.
+//!
+//! An issuer grants a [`Capability`] to an audience by signing a
+//! [`Delegation`]. Delegations can be chained, so a grant can be re-delegated
+//! along a path. An [`Authorizer`] verifies that an invocation of a capability
+//! is backed by a valid, unexpired chain of delegations.
+//!
+//! Take a look at [`Delegation`] and [`Authorizer::check_invocation_from`] to
+//! get started.
+
 use ed25519_dalek::{
     ed25519::signature::Signer, Signature, SigningKey, VerifyingKey, SIGNATURE_LENGTH,
 };
 use n0_error::{e, stack_error};
 use n0_future::time::{Duration, SystemTime};
-use postcard::take_from_bytes;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;
 
-/// Domain separation tag for rcan v2 signatures.
+/// The domain-separation tag distinguishing rcan delegations from other
+/// ed25519-signed data. Exposed for applications that re-verify signatures.
 pub const DST: &[u8] = b"rcan-2-delegation";
 
-/// A trait for types that define a capability.
+/// A capability that can be converted to and from its byte representation.
 ///
-/// Capabilities can be compared using [`Capability::permits`], which determines
-/// whether one capability grants permission to perform another.
-///
-/// A common implementation of this trait might be an enum representing different
-/// RPC request types.
-///
-/// The `Capability` type must be serializable so it can be included in the signature
-/// payload of a [`Delegation`].
-pub trait Capability: Serialize + DeserializeOwned {
-    /// Determines if `self` permits `other`.
+/// The bytes are what a [`Delegation`] stores and signs. You usually won't
+/// implement this yourself: any [`Serialize`] + [`Deserialize`] type is
+/// supported automatically.
+pub trait CapabilityEncoding {
+    /// Returns the bytes this capability is represented as inside a delegation.
+    fn encode(&self) -> Vec<u8>;
+
+    /// Decodes a capability from its bytes.
     ///
-    /// Returns `true` if `self` grants permission to perform the `other` capability,
-    /// otherwise returns `false`.
+    /// # Errors
+    ///
+    /// Returns [`DecodeError::WrongCapability`] if `bytes` is not a valid
+    /// encoding of this capability.
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError>
+    where
+        Self: Sized;
+}
+
+impl<T: Serialize + DeserializeOwned> CapabilityEncoding for T {
+    fn encode(&self) -> Vec<u8> {
+        postcard::to_stdvec(self).expect("capability serializes")
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        match postcard::take_from_bytes::<Self>(bytes) {
+            Ok((value, [])) => Ok(value),
+            _ => Err(e!(DecodeError::WrongCapability)),
+        }
+    }
+}
+
+/// A grantable capability.
+///
+/// Implement this for your own capability type, typically an enum of the
+/// operations or resources you want to authorize. [`permits`] defines how
+/// broader capabilities imply narrower ones.
+///
+/// [`permits`]: Capability::permits
+pub trait Capability: CapabilityEncoding {
+    /// Returns `true` if `self` grants the permissions described by `other`.
     fn permits(&self, other: &Self) -> bool;
 }
 
-/// An authorizer for invocations.
+/// The authority that verifies an invocation.
 ///
-/// This represents an identity in the form of a public key.
-/// This public key will always be the same as the original issuer of
-/// the capabilities that are invoked against the authorizer.
+/// An [`Authorizer`] holds the public key of the identity that first issued a
+/// capability. `check_invocation_from` verifies that an invocation is backed by
+/// an unexpired, unbroken chain of delegations originating from that identity.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Authorizer {
     identity: VerifyingKey,
@@ -42,17 +79,48 @@ pub struct Authorizer {
 
 #[allow(clippy::result_large_err)]
 impl Authorizer {
-    /// Constructs a new authorizer for given identity.
+    /// Returns an authorizer for the given verifying key.
     pub fn new(identity: VerifyingKey) -> Self {
         Self { identity }
     }
 
-    /// Verifies an invocation of a capability owned by this authorizer,
-    /// that may have been passed through delegations in a proof chain
-    /// and was finally signed back to us from given `invoker`.
+    /// Verifies an invocation of `capability` by `invoker`, backed by
+    /// `proof_chain`.
     ///
-    /// Make sure to verify that the `invoker` signed and authenticated the
-    /// message containing the `capability`.
+    /// The chain must start with the delegation issued by this authorizer's
+    /// identity and end at `invoker`. Make sure the invoker signed and
+    /// authenticated the message carrying `capability`; this method only
+    /// checks the capability chain itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ed25519_dalek::SigningKey;
+    /// use rcan::{Authorizer, Capability, Delegation, Expires};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// enum Cap {
+    ///     Read,
+    ///     All,
+    /// }
+    /// impl Capability for Cap {
+    ///     fn permits(&self, other: &Self) -> bool {
+    ///         *self == Cap::All || self == other
+    ///     }
+    /// }
+    ///
+    /// let service = SigningKey::from_bytes(&[0u8; 32]);
+    /// let alice = SigningKey::from_bytes(&[1u8; 32]);
+    ///
+    /// let grant = Delegation::issuing_builder(&service, alice.verifying_key(), &Cap::All)
+    ///     .sign(Expires::Never);
+    ///
+    /// let authorizer = Authorizer::new(service.verifying_key());
+    /// authorizer
+    ///     .check_invocation_from(alice.verifying_key(), Cap::Read, &[&grant])
+    ///     .unwrap();
+    /// ```
     pub fn check_invocation_from<C: Capability>(
         &self,
         invoker: VerifyingKey,
@@ -62,6 +130,11 @@ impl Authorizer {
         self.check_invocation_from_at(SystemTime::now(), invoker, capability, proof_chain)
     }
 
+    /// Like [`check_invocation_from`](Self::check_invocation_from), but evaluates
+    /// expiry against an explicit time instead of "now".
+    ///
+    /// Opaque delegations are not checked directly; parse them into a typed
+    /// delegation with [`OpaqueDelegation::parse`] first, then check them here.
     pub fn check_invocation_from_at<C: Capability>(
         &self,
         now: SystemTime,
@@ -69,144 +142,229 @@ impl Authorizer {
         capability: C,
         proof_chain: &[&Delegation<C>],
     ) -> Result<(), InvocationError> {
-        self.check_invocation_impl(now, invoker, capability_predicate(capability), proof_chain)
-    }
-
-    /// Verifies an opaque invocation of a capability owned by this authorizer,
-    /// that may have been passed through delegations in a proof chain
-    /// and was finally signed back to us from given `invoker`.
-    ///
-    /// Make sure to verify that the `invoker` signed and authenticated the
-    /// message containing the `capability`.
-    pub fn check_opaque_invocation_from<C: Capability>(
-        &self,
-        invoker: VerifyingKey,
-        capability: C,
-        proof_chain: &[&OpaqueDelegation],
-    ) -> Result<(), InvocationError> {
-        self.check_opaque_invocation_from_at(SystemTime::now(), invoker, capability, proof_chain)
-    }
-
-    pub fn check_opaque_invocation_from_at<C: Capability>(
-        &self,
-        now: SystemTime,
-        invoker: VerifyingKey,
-        capability: C,
-        proof_chain: &[&OpaqueDelegation],
-    ) -> Result<(), InvocationError> {
-        self.check_invocation_impl(now, invoker, capability_predicate(capability), proof_chain)
-    }
-
-    /// Implementation of the invocation check, used by both typed and opaque variants.
-    fn check_invocation_impl<T: AsRef<OpaqueDelegation>>(
-        &self,
-        now: SystemTime,
-        invoker: VerifyingKey,
-        permitted: impl Fn(&T) -> bool,
-        proof_chain: &[T],
-    ) -> Result<(), InvocationError> {
-        // We require that proof chains are provided "back-to-front".
-        // So they start with the owner of the capability, then
-        // proceed with the next item in the chain.
-        let mut current_issuer_target = &self.identity;
-        for original in proof_chain {
-            let proof = original.as_ref();
-            // Verify proof chain issuer/audience integrity:
-            let issuer = proof.issuer();
-            if issuer != current_issuer_target {
+        // The chain is checked back-to-front: it starts at the owner of the
+        // capability and each delegation names the next issuer.
+        let mut current_issuer = &self.identity;
+        for proof in proof_chain {
+            if proof.issuer() != current_issuer {
                 return Err(e!(InvocationError::ChainBroken {
-                    expected: *current_issuer_target,
-                    found: *issuer,
+                    expected: *current_issuer,
+                    found: *proof.issuer(),
                 }));
             }
-
-            // Verify each proof's time validity:
-            let expiry = proof.expires();
-            if !expiry.is_valid_at(now) {
+            if !proof.expires().is_valid_at(now) {
                 return Err(e!(InvocationError::Expired {
-                    expiry: expiry.clone(),
+                    expiry: proof.expires().clone(),
                 }));
             }
-
-            // Verify that the capability is actually reached through:
             if proof.capability_issuer() != &self.identity {
                 return Err(e!(InvocationError::WrongCapabilityIssuer {
                     authorizer: self.identity,
                 }));
             }
-
-            // Verify that the capability doesn't break out of capabilities:
-            if !permitted(original) {
+            if !proof.payload().capability().permits(&capability) {
                 return Err(e!(InvocationError::NotPermitted));
             }
-
-            // Continue checking the proof chain's integrity with this
-            // delegation's audience as the next issuer target:
-            current_issuer_target = proof.audience();
+            current_issuer = proof.audience();
         }
-
-        if &invoker != current_issuer_target {
+        if &invoker != current_issuer {
             return Err(e!(InvocationError::WrongInvoker {
                 invoker,
-                chain_end: *current_issuer_target,
+                chain_end: *current_issuer,
             }));
         }
-
         Ok(())
     }
 }
 
-/// Create a predicate to check a capability `C` against a delegation type `T`.
+/// A capability as raw, uninterpreted bytes.
 ///
-/// The predicate will return true if the capability bytes can be deserialized as `C`
-/// with no trailing bytes, and the deserialized capability permits the given `capability`.
-fn capability_predicate<C: Capability, T: AsRef<OpaqueDelegation>>(
-    capability: C,
-) -> impl Fn(&T) -> bool {
-    move |proof| match postcard::take_from_bytes::<C>(proof.as_ref().capability()) {
-        Ok((granted, [])) => granted.permits(&capability),
-        _ => false,
+/// Used by [`OpaqueDelegation`] to carry a delegation whose capability type is
+/// not (yet) known. Any byte string is a valid `OpaqueCapability`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OpaqueCapability(Vec<u8>);
+
+impl OpaqueCapability {
+    /// Returns the underlying capability bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 }
 
-/// A token for attenuated capability delegations.
+impl CapabilityEncoding for OpaqueCapability {
+    fn encode(&self) -> Vec<u8> {
+        self.0.clone()
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        Ok(Self(bytes.to_vec()))
+    }
+}
+
+impl Capability for OpaqueCapability {
+    fn permits(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+/// A delegation whose capability is held as raw bytes rather than a typed
+/// value. See [`Delegation`].
+pub type OpaqueDelegation = Delegation<OpaqueCapability>;
+
+impl Delegation<OpaqueCapability> {
+    /// Parses this delegation's capability bytes as a `C`, yielding a typed
+    /// [`Delegation<C>`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError::WrongCapability`] if the bytes are not a valid
+    /// encoding of `C` (unless `C` is [`OpaqueCapability`], which accepts any
+    /// bytes).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ed25519_dalek::SigningKey;
+    /// use rcan::{Delegation, Expires, OpaqueDelegation};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// enum Cap {
+    ///     Read,
+    /// }
+    ///
+    /// let key = SigningKey::from_bytes(&[0u8; 32]);
+    /// let typed =
+    ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
+    /// let opaque = typed.into_opaque();
+    /// let back: Delegation<Cap> = opaque.parse().unwrap();
+    /// ```
+    pub fn parse<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
+        let capability = C::decode(self.payload.capability.as_bytes())?;
+        Ok(Delegation::new(
+            Payload {
+                issuer: self.payload.issuer,
+                audience: self.payload.audience,
+                capability_origin: self.payload.capability_origin,
+                valid_until: self.payload.valid_until,
+                capability,
+            },
+            self.signature,
+        ))
+    }
+}
+
+/// A signed delegation granting a capability.
 ///
-/// An [`OpaqueDelegation`] is guaranteed to be a valid delegation with a valid
-/// signature.
+/// A `Delegation<C>` is a signed capability grant: it records who issued it,
+/// who it was granted to (`audience`), what capability it carries, and when it
+/// expires. Delegations can be chained (see [`CapabilityOrigin`]) so a receiver
+/// can re-delegate an attenuated capability it was given.
 ///
-/// The opaque variant keeps the capability as a byte array.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpaqueDelegation {
-    payload: Payload,
+/// The [`OpaqueDelegation`] form carries the capability as raw bytes and is
+/// turned into a typed `Delegation<C>` with [`parse`](OpaqueDelegation::parse).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Delegation<C> {
+    payload: Payload<C>,
     signature: Signature,
 }
 
-impl OpaqueDelegation {
-    /// Decodes a v2 delegation from bytes, verifying the signature and canonical encoding.
-    ///
-    /// Currently this is the only supported version.
-    fn decode_v2(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let (payload, signature) = read_signed::<Payload>(bytes)?;
-        let to_verify = postcard::to_extend(&payload, DST.to_vec()).expect("payload serializes");
-        if to_verify[DST.len()..] != bytes[..bytes.len() - SIGNATURE_LENGTH] {
-            return Err(DecodeError::malformed("non canonical encoding of payload"));
-        }
-        payload
-            .issuer
-            .verify_strict(&to_verify, &signature)
-            .map_err(|_| e!(DecodeError::InvalidSignature))?;
-        Ok(Self { payload, signature })
+impl<C> Delegation<C> {
+    /// Constructs a new delegation from a payload and signature.
+    fn new(payload: Payload<C>, signature: Signature) -> Self {
+        Self { payload, signature }
     }
 
-    /// Decodes a delegation from bytes, verifying the signature and canonical encoding.
+    /// Returns the delegation's payload.
+    pub fn payload(&self) -> &Payload<C> {
+        &self.payload
+    }
+
+    /// Returns the delegation's signature.
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Returns the issuing identity.
+    pub fn issuer(&self) -> &VerifyingKey {
+        self.payload.issuer()
+    }
+
+    /// Returns the identity this delegation was granted to.
+    pub fn audience(&self) -> &VerifyingKey {
+        self.payload.audience()
+    }
+
+    /// Returns the origin of the delegated capability.
+    pub fn capability_origin(&self) -> &CapabilityOrigin {
+        self.payload.capability_origin()
+    }
+
+    /// Returns the identity that originally held the capability.
+    pub fn capability_issuer(&self) -> &VerifyingKey {
+        self.payload.capability_issuer()
+    }
+
+    /// Returns when this delegation expires.
+    pub fn expires(&self) -> &Expires {
+        self.payload.expires()
+    }
+}
+
+impl<C: Clone> Delegation<C> {
+    /// Returns a copy of the stored capability.
+    pub fn capability(&self) -> C {
+        self.payload.capability().clone()
+    }
+}
+
+impl<C: CapabilityEncoding> Delegation<C> {
+    /// Turns this delegation into an [`OpaqueDelegation`], encoding the
+    /// capability to bytes.
+    pub fn into_opaque(self) -> OpaqueDelegation {
+        let encoded = C::encode(&self.payload.capability);
+        OpaqueDelegation::new(
+            Payload {
+                issuer: self.payload.issuer,
+                audience: self.payload.audience,
+                capability_origin: self.payload.capability_origin,
+                valid_until: self.payload.valid_until,
+                capability: OpaqueCapability(encoded),
+            },
+            self.signature,
+        )
+    }
+
+    /// Returns the delegation's byte encoding.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut res = vec![2u8];
+        encode_payload(&self.payload, &mut res);
+        res.extend_from_slice(&self.signature.to_bytes());
+        res
+    }
+
+    /// Returns a lowercase base32 string of the delegation's byte encoding,
+    /// useful for compact, printable representations.
+    pub fn encode_string(&self) -> String {
+        let mut out = data_encoding::BASE32_NOPAD.encode(&self.encode());
+        out.make_ascii_lowercase();
+        out
+    }
+
+    /// Decodes a delegation from its byte encoding, verifying the signature and
+    /// decoding the capability as `C`.
     ///
-    /// `decode` will not work for v1 delegations. Attempting to decode a v1 delegation
-    /// will return a [`DecodeError::UnsupportedV1`] error.
+    /// # Errors
+    ///
+    /// Returns [`DecodeError::UnsupportedV1`] for legacy format tokens,
+    /// [`DecodeError::WrongCapability`] if the capability is not a valid `C`,
+    /// and other [`DecodeError`]s if the token is malformed or its signature is
+    /// invalid.
     pub fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
         match bytes.split_first() {
             None => Err(DecodeError::malformed("token is empty")),
             Some((0x01, _)) | Some((0x20, _)) => Err(e!(DecodeError::UnsupportedV1)),
-            Some((0x02, bytes)) => Self::decode_v2(bytes),
+            Some((0x02, bytes)) => decode_v2_checked::<C>(bytes),
             Some((v, _)) => Err(DecodeError::malformed(format!(
                 "unknown version byte {:#x}",
                 v
@@ -214,264 +372,74 @@ impl OpaqueDelegation {
         }
     }
 
-    /// Encodes the delegation into bytes, including the version byte.
-    pub fn encode(&self) -> Vec<u8> {
-        let mut res = postcard::to_extend(&self.payload, vec![2u8]).expect("payload serializes");
-        res.extend_from_slice(&self.signature.to_bytes());
-        res
-    }
-
-    /// Encodes the delegation into a base32 string of the byte encoding produced
-    /// by [`Self::encode`].
-    pub fn encode_string(&self) -> String {
-        let mut out = data_encoding::BASE32_NOPAD.encode(&self.encode());
-        out.make_ascii_lowercase();
-        out
-    }
-
-    /// Decodes a delegation from a base32 string, verifying the signature and canonical encoding.
-    pub fn decode_string(s: &str) -> Result<Self, DecodeError> {
-        Self::decode(&base32_bytes(s)?)
-    }
-
-    /// The payload of the delegation.
-    pub fn payload(&self) -> &Payload {
-        &self.payload
-    }
-
-    /// The signature of the delegation.
-    pub fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    /// The issuer of the delegation.
-    pub fn issuer(&self) -> &VerifyingKey {
-        self.payload().issuer()
-    }
-
-    /// The audience of the delegation.
-    pub fn audience(&self) -> &VerifyingKey {
-        self.payload().audience()
-    }
-
-    /// The origin of the capability in the delegation.
-    pub fn capability_origin(&self) -> &CapabilityOrigin {
-        self.payload().capability_origin()
-    }
-
-    /// The issuer of the capability in the delegation.
-    pub fn capability_issuer(&self) -> &VerifyingKey {
-        self.payload().capability_issuer()
-    }
-
-    /// The expiration of the delegation.
-    pub fn expires(&self) -> &Expires {
-        self.payload().expires()
-    }
-
-    /// The capability of the delegation, as a byte slice.
-    pub fn capability(&self) -> &[u8] {
-        self.payload().capability()
-    }
-}
-
-/// A token for attenuated capability delegations.
-///
-/// An [`Delegation<C>`] is guaranteed to be a valid delegation with a valid
-/// signature. Also it is guaranteed that the capability bytes can be
-/// deserialized as `C` with no trailing bytes.
-///
-/// The capability is currently kept as a byte array, but that is an
-/// implementation detail.
-pub struct Delegation<C> {
-    opaque: OpaqueDelegation,
-    _marker: std::marker::PhantomData<C>,
-}
-
-impl<C> Delegation<C> {
-    /// Constructs a new delegation from an opaque delegation.
-    ///
-    /// Callers must make sure that the capability bytes in the opaque delegation
-    /// can be deserialized as `C` with no trailing bytes.
-    fn new(opaque: OpaqueDelegation) -> Self {
-        Self {
-            opaque,
-            _marker: std::marker::PhantomData,
-        }
-    }
-
-    /// A reference to the underlying opaque delegation.
-    pub fn opaque(&self) -> &OpaqueDelegation {
-        &self.opaque
-    }
-
-    /// Consumes the delegation and returns the underlying opaque delegation.
-    pub fn into_opaque(self) -> OpaqueDelegation {
-        self.opaque
-    }
-
-    /// The payload of the delegation.
-    pub fn payload(&self) -> &Payload {
-        self.opaque.payload()
-    }
-
-    /// The signature of the delegation.
-    pub fn signature(&self) -> &Signature {
-        self.opaque.signature()
-    }
-
-    /// The issuer of the delegation.
-    pub fn issuer(&self) -> &VerifyingKey {
-        self.opaque.issuer()
-    }
-
-    /// The audience of the delegation.
-    pub fn audience(&self) -> &VerifyingKey {
-        self.opaque.audience()
-    }
-
-    /// The origin of the capability.
-    pub fn capability_origin(&self) -> &CapabilityOrigin {
-        self.opaque.capability_origin()
-    }
-
-    /// The issuer of the capability.
-    pub fn capability_issuer(&self) -> &VerifyingKey {
-        self.opaque.capability_issuer()
-    }
-
-    /// The expiration of the delegation.
-    pub fn expires(&self) -> &Expires {
-        self.opaque.expires()
-    }
-
-    /// Encodes the delegation into a blob according to the rcan v2 format, including the version byte.
-    pub fn encode(&self) -> Vec<u8> {
-        self.opaque.encode()
-    }
-
-    /// Encodes the delegation into a base32 string of the byte encoding produced
-    /// by [`Self::encode`].
-    pub fn encode_string(&self) -> String {
-        self.opaque.encode_string()
-    }
-}
-
-impl<C: Serialize + DeserializeOwned> Delegation<C> {
-    /// The capability of the delegation, deserialized as `C`.
-    ///
-    /// Currently this produces a new capability instance on each call.
-    pub fn capability(&self) -> C {
-        postcard::from_bytes(self.opaque.capability()).expect("invariant: capability parses as C")
-    }
-
-    /// Decodes a delegation from bytes, verifying the signature and canonical encoding.
-    pub fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let delegation = OpaqueDelegation::decode(bytes)?;
-        Delegation::<C>::try_from(delegation)
-    }
-
-    /// Decodes a delegation from a base32 string, verifying the signature and canonical encoding.
+    /// Decodes a delegation from a base32 string, verifying the signature and
+    /// decoding the capability as `C`. See [`decode`](Delegation::decode).
     pub fn decode_string(s: &str) -> Result<Self, DecodeError> {
         Self::decode(&base32_bytes(s)?)
     }
 }
 
-/// Converts an opaque delegation into a typed delegation, verifying that the capability
-/// bytes can be deserialized as `C` with no trailing bytes.
-impl<C: Serialize + DeserializeOwned> TryFrom<OpaqueDelegation> for Delegation<C> {
-    type Error = DecodeError;
-
-    fn try_from(delegation: OpaqueDelegation) -> Result<Self, DecodeError> {
-        match postcard::take_from_bytes::<C>(delegation.capability()) {
-            Ok((_, [])) => Ok(Self::new(delegation)),
-            _ => Err(e!(DecodeError::WrongCapability)),
-        }
+/// Decodes a v2 delegation, verifying the signature and canonical encoding and
+/// that the capability decodes as `C`.
+fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C>, DecodeError> {
+    if bytes.len() < SIGNATURE_LENGTH {
+        return Err(DecodeError::malformed("invalid signature length"));
     }
+    let (payload_bytes, sig_bytes) = bytes.split_at(bytes.len() - SIGNATURE_LENGTH);
+    let (payload, used) = decode_payload::<C>(payload_bytes)?;
+    if used != payload_bytes.len() {
+        return Err(DecodeError::malformed("non canonical encoding of payload"));
+    }
+    let signature = Signature::from_bytes(
+        sig_bytes
+            .try_into()
+            .map_err(|_| DecodeError::malformed("invalid signature length"))?,
+    );
+    let mut to_verify = DST.to_vec();
+    encode_payload::<C>(&payload, &mut to_verify);
+    if to_verify[DST.len()..] != *payload_bytes {
+        return Err(DecodeError::malformed("non canonical encoding of payload"));
+    }
+    payload
+        .issuer
+        .verify_strict(&to_verify, &signature)
+        .map_err(|_| e!(DecodeError::InvalidSignature))?;
+    Ok(Delegation::new(payload, signature))
 }
 
-/// Converts a typed delegation into an opaque delegation.
-impl<C> From<Delegation<C>> for OpaqueDelegation {
-    fn from(typed: Delegation<C>) -> Self {
-        typed.opaque
-    }
-}
-
-/// Allows sharing the invocation check code between typed and opaque delegations.
-impl<C> AsRef<OpaqueDelegation> for Delegation<C> {
-    fn as_ref(&self) -> &OpaqueDelegation {
-        self.opaque()
-    }
-}
-
-/// Allows sharing the invocation check code between typed and opaque delegations.
-impl AsRef<OpaqueDelegation> for OpaqueDelegation {
-    fn as_ref(&self) -> &OpaqueDelegation {
-        self
-    }
-}
-
-impl<C> std::fmt::Debug for Delegation<C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // this isn't nice, but not doing this would require a `C: Debug` bound.
-        self.opaque.fmt(f)
-    }
-}
-
-/// Manual instance due to the phantom type parameter `C`.
-impl<C> Clone for Delegation<C> {
-    fn clone(&self) -> Self {
-        Self::new(self.opaque.clone())
-    }
-}
-
-/// Manual instance due to the phantom type parameter `C`.
-impl<C> PartialEq for Delegation<C> {
-    fn eq(&self, other: &Self) -> bool {
-        self.opaque == other.opaque
-    }
-}
-
-/// Manual instance due to the phantom type parameter `C`.
-impl<C> Eq for Delegation<C> {}
-
-/// The payload of a delegation.
-#[derive(Clone, Serialize, Deserialize, derive_more::Debug, PartialEq, Eq)]
-pub struct Payload {
-    /// The issuer
-    #[debug("{}", hex::encode(issuer))]
-    #[serde(with = "verifying_key_serde")]
+/// The signed contents of a [`Delegation`]: the parties, the capability, and
+/// its expiry. Prefer the accessors on [`Delegation`] over this type directly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Payload<C> {
+    /// The issuing identity
     issuer: VerifyingKey,
     /// The intended audience
-    #[debug("{}", hex::encode(audience))]
-    #[serde(with = "verifying_key_serde")]
     audience: VerifyingKey,
     /// The origin of the capability
     capability_origin: CapabilityOrigin,
-    /// Valid until unix timestamp in seconds.
+    /// When the delegation expires
     valid_until: Expires,
     /// The capability
-    #[debug("{}", hex::encode(capability))]
-    capability: Vec<u8>,
+    capability: C,
 }
 
-impl Payload {
-    /// The issuer of the delegation.
+impl<C> Payload<C> {
+    /// Returns the issuing identity.
     pub fn issuer(&self) -> &VerifyingKey {
         &self.issuer
     }
 
-    /// The audience of the delegation.
+    /// Returns the identity this delegation was granted to.
     pub fn audience(&self) -> &VerifyingKey {
         &self.audience
     }
 
-    /// The origin of the capability.
+    /// Returns the origin of the delegated capability.
     pub fn capability_origin(&self) -> &CapabilityOrigin {
         &self.capability_origin
     }
 
-    /// The issuer of the capability.
+    /// Returns the identity that originally held the capability.
     pub fn capability_issuer(&self) -> &VerifyingKey {
         match &self.capability_origin {
             CapabilityOrigin::Issuer => &self.issuer,
@@ -479,39 +447,39 @@ impl Payload {
         }
     }
 
-    /// When the delegation expires.
+    /// Returns when this payload expires.
     pub fn expires(&self) -> &Expires {
         &self.valid_until
     }
 
-    /// The capability of the delegation, as a byte slice.
-    pub fn capability(&self) -> &[u8] {
+    /// Returns the capability.
+    pub fn capability(&self) -> &C {
         &self.capability
     }
 }
 
-/// The potential origins of a capability.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+/// Where a delegated capability comes from.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CapabilityOrigin {
-    /// The origin is the issuer itself
+    /// The capability originates with the delegating identity itself.
     Issuer,
-    /// This is a delegation, with this key being the root of the delegation chain.
-    Delegation(#[serde(with = "verifying_key_serde")] VerifyingKey),
+    /// The capability was previously granted by this root identity.
+    Delegation(VerifyingKey),
 }
 
-/// When a delegation expires
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, derive_more::Display)]
+/// When a delegation expires.
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::Display)]
 pub enum Expires {
-    /// Never expires
+    /// The delegation never expires.
     #[display("never")]
     Never,
-    /// Valid until given unix timestamp in seconds
+    /// The delegation is valid until the given Unix timestamp (in seconds).
     #[display("{_0}")]
     At(u64),
 }
 
 impl Expires {
-    /// Creates an `Expires` value that is valid for the given duration from now.
+    /// Returns an expiry `duration` from now.
     pub fn valid_for(duration: Duration) -> Self {
         Self::At(
             (SystemTime::now()
@@ -522,7 +490,7 @@ impl Expires {
         )
     }
 
-    /// Checks if the `Expires` value is valid at the given `SystemTime`.
+    /// Returns `true` if the delegation is still valid at `time`.
     pub fn is_valid_at(&self, time: SystemTime) -> bool {
         let time = time
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -535,8 +503,9 @@ impl Expires {
     }
 }
 
-impl<C: Serialize> Delegation<C> {
-    /// Creates a builder for issuing a new delegation where the issuer is the origin of the capability.
+impl<C: Clone> Delegation<C> {
+    /// Returns a builder for a delegation that `issuer` issues to `audience`
+    /// for `capability`, where `issuer` is the origin of the capability.
     pub fn issuing_builder<'s>(
         issuer: &'s SigningKey,
         audience: VerifyingKey,
@@ -546,12 +515,12 @@ impl<C: Serialize> Delegation<C> {
             issuer,
             audience,
             capability_origin: CapabilityOrigin::Issuer,
-            capability: postcard::to_stdvec(capability).expect("capability serializes"),
-            capability_type: std::marker::PhantomData,
+            capability: capability.clone(),
         }
     }
 
-    /// Creates a builder for issuing a new delegation where the capability originates from another delegation.
+    /// Returns a builder for a delegation that `issuer` issues to `audience`
+    /// for `capability`, where the capability was originally held by `owner`.
     pub fn delegating_builder<'s>(
         issuer: &'s SigningKey,
         audience: VerifyingKey,
@@ -562,23 +531,22 @@ impl<C: Serialize> Delegation<C> {
             issuer,
             audience,
             capability_origin: CapabilityOrigin::Delegation(owner),
-            capability: postcard::to_stdvec(capability).expect("capability serializes"),
-            capability_type: std::marker::PhantomData,
+            capability: capability.clone(),
         }
     }
 }
 
-/// A builder for creating a delegation.
+/// Builds and signs a [`Delegation`].
 pub struct DelegationBuilder<'s, C> {
     issuer: &'s SigningKey,
     audience: VerifyingKey,
     capability_origin: CapabilityOrigin,
-    capability: Vec<u8>,
-    capability_type: std::marker::PhantomData<C>,
+    capability: C,
 }
 
-impl<C> DelegationBuilder<'_, C> {
-    /// Signs the delegation with the given expiration time, returning a `Delegation<C>`.
+impl<C: CapabilityEncoding + Clone> DelegationBuilder<'_, C> {
+    /// Signs the delegation, returning a [`Delegation<C>`] valid until
+    /// `valid_until`.
     pub fn sign(self, valid_until: Expires) -> Delegation<C> {
         let payload = Payload {
             issuer: self.issuer.verifying_key(),
@@ -587,32 +555,33 @@ impl<C> DelegationBuilder<'_, C> {
             valid_until,
             capability: self.capability,
         };
-        let to_sign = postcard::to_extend(&payload, DST.to_vec()).expect("payload serializes");
+        let mut to_sign = DST.to_vec();
+        encode_payload(&payload, &mut to_sign);
         let signature = self.issuer.sign(&to_sign);
-        Delegation::new(OpaqueDelegation { payload, signature })
+        Delegation::new(payload, signature)
     }
 }
 
-/// Error types for decoding.
+/// Errors produced when decoding a delegation.
 #[stack_error(derive, add_meta)]
 #[non_exhaustive]
 pub enum DecodeError {
-    /// The input is malformed in some way, with a reason provided.
+    /// The input is malformed, with a reason.
     #[error("malformed token: {reason}")]
     Malformed { reason: String },
-    /// The input is a v1 token, which is not supported by this version of the library.
+    /// The input is a version-1 (legacy) token; use rcan 0.4.x to read those.
     #[error("v1 tokens are not supported, use rcan 0.4.x to read them")]
     UnsupportedV1,
-    /// The signature on the token is invalid.
+    /// The token's signature is invalid.
     #[error("signature verification failed")]
     InvalidSignature,
-    /// The capability in the token does not parse as the expected capability type.
+    /// The token's capability is not a valid encoding of the expected type.
     #[error("capability does not parse as the expected capability type")]
     WrongCapability,
 }
 
 impl DecodeError {
-    /// Helper to create a `DecodeError::Malformed` with a reason.
+    /// Returns a `Malformed` error for the given `reason`.
     fn malformed(reason: impl std::fmt::Display) -> Self {
         e!(DecodeError::Malformed {
             reason: reason.to_string()
@@ -620,12 +589,12 @@ impl DecodeError {
     }
 }
 
-/// Error types for invocation checks.
+/// Errors produced while verifying an invocation.
 #[stack_error(derive, add_meta)]
 #[non_exhaustive]
 pub enum InvocationError {
-    /// The proof chain is broken. The issuer of a delegation does not match the
-    /// audience of the previous delegation in the chain.
+    /// The proof chain is broken: a delegation was issued by a different
+    /// identity than the previous delegation was granted to.
     #[error(
         "expected proof to be issued by {}, but was issued by {}",
         hex::encode(expected),
@@ -635,16 +604,16 @@ pub enum InvocationError {
         expected: VerifyingKey,
         found: VerifyingKey,
     },
-    /// The proof has expired.
+    /// A delegation in the chain has expired.
     #[error("proof expired at {expiry}")]
     Expired { expiry: Expires },
     #[error(
         "proof is missing delegation for capability of {}",
         hex::encode(authorizer)
     )]
-    /// A delegation in the proof chain does not have the correct capability issuer.
+    /// A delegation in the chain does not convey the authorizer's capability.
     WrongCapabilityIssuer { authorizer: VerifyingKey },
-    /// The capability in the proof chain does not permit the requested capability.
+    /// No delegation in the chain permits the requested capability.
     #[error("capability not permitted")]
     NotPermitted,
     #[error(
@@ -652,116 +621,126 @@ pub enum InvocationError {
         hex::encode(invoker),
         hex::encode(chain_end)
     )]
-    /// The final audience in the proof chain does not match the invoker of the capability.
+    /// The final audience in the chain does not match the invoker.
     WrongInvoker {
         invoker: VerifyingKey,
         chain_end: VerifyingKey,
     },
 }
 
-/// Forward all serialization of `OpaqueDelegation` to [`OpaqueDelegation::encode`].
-impl Serialize for OpaqueDelegation {
+/// Serializes the delegation as its byte encoding, or as a base32 string when
+/// the format is human-readable. See [`Delegation::encode`].
+impl<C: CapabilityEncoding> Serialize for Delegation<C> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.encode_string())
         } else {
-            serializer.serialize_bytes(&self.encode())
+            self.encode().serialize(serializer)
         }
     }
 }
 
-/// Forward all deserialization of `OpaqueDelegation` to [`OpaqueDelegation::decode`].
-impl<'de> Deserialize<'de> for OpaqueDelegation {
+/// See [`Delegation::decode`], which this forwards to.
+impl<'de, C: CapabilityEncoding> Deserialize<'de> for Delegation<C> {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use serde::de::Error;
-        if deserializer.is_human_readable() {
+        let delegation = if deserializer.is_human_readable() {
             let s = String::deserialize(deserializer)?;
-            Self::decode_string(&s).map_err(D::Error::custom)
+            Self::decode_string(&s)
         } else {
-            let bytes = deserialize_byte_buf(deserializer)?;
-            Self::decode(&bytes).map_err(D::Error::custom)
-        }
+            let v = Vec::<u8>::deserialize(deserializer)?;
+            Self::decode(&v)
+        };
+        delegation.map_err(D::Error::custom)
     }
 }
 
-/// Deserialize an owned byte buffer without requiring `serde_bytes`.
-fn deserialize_byte_buf<'de, D: serde::Deserializer<'de>>(
-    deserializer: D,
-) -> Result<Vec<u8>, D::Error> {
-    struct ByteBufVisitor;
-
-    impl<'de> serde::de::Visitor<'de> for ByteBufVisitor {
-        type Value = Vec<u8>;
-
-        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            formatter.write_str("a byte string")
-        }
-
-        fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
-            Ok(bytes.to_vec())
-        }
-
-        fn visit_borrowed_bytes<E: serde::de::Error>(
-            self,
-            bytes: &'de [u8],
-        ) -> Result<Self::Value, E> {
-            Ok(bytes.to_vec())
-        }
-
-        fn visit_byte_buf<E: serde::de::Error>(self, bytes: Vec<u8>) -> Result<Self::Value, E> {
-            Ok(bytes)
+/// Encodes the payload into its canonical byte representation (the part of the
+/// wire format that gets signed, without the leading version byte).
+fn encode_payload<C: CapabilityEncoding>(payload: &Payload<C>, out: &mut Vec<u8>) {
+    out.extend_from_slice(payload.issuer.as_bytes());
+    out.extend_from_slice(payload.audience.as_bytes());
+    match &payload.capability_origin {
+        CapabilityOrigin::Issuer => bijoux::u64::encode(0, out),
+        CapabilityOrigin::Delegation(root) => {
+            bijoux::u64::encode(1, out);
+            out.extend_from_slice(root.as_bytes());
         }
     }
-
-    deserializer.deserialize_byte_buf(ByteBufVisitor)
+    match &payload.valid_until {
+        Expires::Never => bijoux::u64::encode(0, out),
+        Expires::At(t) => {
+            bijoux::u64::encode(1, out);
+            bijoux::u64::encode(*t, out);
+        }
+    }
+    let capability = C::encode(&payload.capability);
+    bijoux::u64::encode(capability.len() as u64, out);
+    out.extend_from_slice(&capability);
 }
 
-/// Forward all serialization of `Delegation<C>` to [`OpaqueDelegation`].
-impl<C> Serialize for Delegation<C> {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.opaque.serialize(serializer)
+/// Decodes a payload from its canonical byte representation, returning it along
+/// with the number of bytes consumed. The capability is decoded as `C`.
+fn decode_payload<C: CapabilityEncoding>(bytes: &[u8]) -> Result<(Payload<C>, usize), DecodeError> {
+    let mut cursor = 0usize;
+    macro_rules! take {
+        ($n:expr) => {{
+            let end = cursor
+                .checked_add($n)
+                .ok_or_else(|| DecodeError::malformed("payload length overflow"))?;
+            let slice = bytes
+                .get(cursor..end)
+                .ok_or_else(|| DecodeError::malformed("payload is truncated"))?;
+            cursor = end;
+            slice
+        }};
     }
-}
-
-/// Forward all deserialization of `Delegation<C>` to [`OpaqueDelegation`].
-impl<'de, C: Serialize + DeserializeOwned> Deserialize<'de> for Delegation<C> {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use serde::de::Error;
-        let opaque = OpaqueDelegation::deserialize(deserializer)?;
-        Self::try_from(opaque).map_err(D::Error::custom)
-    }
-}
-
-/// Custom serialization and deserialization for [`ed25519_dalek::VerifyingKey`]
-/// via its byte representation.
-pub(crate) mod verifying_key_serde {
-    use ed25519_dalek::VerifyingKey;
-    use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn serialize<S: Serializer>(key: &VerifyingKey, serializer: S) -> Result<S::Ok, S::Error> {
-        key.as_bytes().serialize(serializer)
+    macro_rules! take_u64 {
+        () => {{
+            let (value, consumed) = bijoux::u64::decode(&bytes[cursor..])
+                .map_err(|e| DecodeError::malformed(format!("invalid varint: {e}")))?;
+            cursor += consumed;
+            value
+        }};
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<VerifyingKey, D::Error> {
-        let buf = <[u8; 32]>::deserialize(deserializer)?;
-        VerifyingKey::from_bytes(&buf).map_err(D::Error::custom)
-    }
-}
+    let issuer = VerifyingKey::from_bytes(take!(32).try_into().expect("32 bytes"))
+        .map_err(|_| DecodeError::malformed("invalid issuer"))?;
+    let audience = VerifyingKey::from_bytes(take!(32).try_into().expect("32 bytes"))
+        .map_err(|_| DecodeError::malformed("invalid audience"))?;
+    let capability_origin = match take_u64!() {
+        0 => CapabilityOrigin::Issuer,
+        1 => {
+            let root = VerifyingKey::from_bytes(take!(32).try_into().expect("32 bytes"))
+                .map_err(|_| DecodeError::malformed("invalid capability origin"))?;
+            CapabilityOrigin::Delegation(root)
+        }
+        tag => {
+            return Err(DecodeError::malformed(format!(
+                "unknown capability origin tag {tag}"
+            )))
+        }
+    };
+    let valid_until = match take_u64!() {
+        0 => Expires::Never,
+        1 => Expires::At(take_u64!()),
+        tag => return Err(DecodeError::malformed(format!("unknown expires tag {tag}"))),
+    };
+    let cap_len = usize::try_from(take_u64!())
+        .map_err(|_| DecodeError::malformed("capability length overflow"))?;
+    let cap_bytes = take!(cap_len);
+    let capability = C::decode(cap_bytes)?;
 
-/// Helper function to read a buffer as a type `T` and a 64 byte signature.
-///
-/// This does not check that the encoding was canonical and also does not check
-/// the signature.
-fn read_signed<T: DeserializeOwned>(bytes: &[u8]) -> Result<(T, Signature), DecodeError> {
-    let (payload, signature) = take_from_bytes::<T>(bytes).map_err(DecodeError::malformed)?;
-    let signature = Signature::from_bytes(
-        signature
-            .try_into()
-            .map_err(|_| DecodeError::malformed("invalid signature length"))?,
-    );
-    Ok((payload, signature))
+    Ok((
+        Payload {
+            issuer,
+            audience,
+            capability_origin,
+            valid_until,
+            capability,
+        },
+        cursor,
+    ))
 }
 
 /// Decodes a string as case insensitive base32, returning the bytes.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@ use n0_future::time::{Duration, SystemTime};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Authorizer, Capability, DecodeError, Delegation, Expires, InvocationError, OpaqueDelegation,
+    Authorizer, Capability, DecodeError, Delegation, Expires, InvocationError, OpaqueCapability,
     BASE32_LOWER_NOPAD,
 };
 
@@ -98,7 +98,7 @@ fn wire_snapshots() {
         never
     );
 
-    let opaque = OpaqueDelegation::decode(&bytes).unwrap();
+    let opaque = Delegation::decode(&bytes).unwrap();
     assert_eq!(opaque, v2.into_opaque());
 }
 
@@ -108,7 +108,7 @@ fn string_snapshots() {
     assert_eq!(v2.encode_string(), V2_STRING);
     assert_eq!(Delegation::<Rpc>::decode_string(V2_STRING).unwrap(), v2);
 
-    let opaque = OpaqueDelegation::decode_string(V2_STRING).unwrap();
+    let opaque = Delegation::decode_string(V2_STRING).unwrap();
     assert_eq!(opaque, v2.into_opaque());
 
     let mut bytes = BASE32_LOWER_NOPAD.decode(V2_STRING.as_bytes()).unwrap();
@@ -129,9 +129,9 @@ fn serde_delegates_to_encode() {
     assert_eq!(wire, postcard_expected);
     assert_eq!(postcard::from_bytes::<Delegation<Rpc>>(&wire).unwrap(), v2);
     // The opaque form round-trips through the same wire encoding.
-    let opaque: OpaqueDelegation = v2.clone().into_opaque();
+    let opaque: Delegation = v2.clone().into_opaque();
     assert_eq!(opaque.encode(), v2.encode());
-    assert_eq!(OpaqueDelegation::decode(&v2.encode()).unwrap(), opaque);
+    assert_eq!(Delegation::decode(&v2.encode()).unwrap(), opaque);
 
     let mut cbor = Vec::new();
     ciborium::into_writer(&v2, &mut cbor).unwrap();
@@ -204,7 +204,7 @@ fn rejects_v1() {
         let bytes = [lead; 8];
         let err = Delegation::<Rpc>::decode(&bytes).unwrap_err();
         assert_matches!(err, DecodeError::UnsupportedV1 { .. });
-        let err = OpaqueDelegation::decode(&bytes).unwrap_err();
+        let err = Delegation::<OpaqueCapability>::decode(&bytes).unwrap_err();
         assert_matches!(err, DecodeError::UnsupportedV1 { .. });
     }
 }
@@ -214,12 +214,12 @@ fn opaque_roundtrip() {
     let typed = delegation();
     assert_eq!(*typed.capability(), Rpc::ReadWrite);
 
-    let untyped: OpaqueDelegation = typed.clone().into_opaque();
-    let again = untyped.clone().parse::<Rpc>().unwrap();
+    let untyped: Delegation = typed.clone().into_opaque();
+    let again = untyped.clone().try_into_typed::<Rpc>().unwrap();
     assert_eq!(again, typed);
 
-    let decoded = OpaqueDelegation::decode(&typed.encode()).unwrap();
-    let again = decoded.parse::<Rpc>().unwrap();
+    let decoded = Delegation::decode(&typed.encode()).unwrap();
+    let again = decoded.try_into_typed::<Rpc>().unwrap();
     assert_eq!(again, typed);
 }
 
@@ -232,8 +232,8 @@ fn rejects_wrong_capability_type() {
     }
 
     let typed = delegation();
-    let untyped: OpaqueDelegation = typed.clone().into_opaque();
-    let err = untyped.parse::<OtherCapability>().unwrap_err();
+    let untyped: Delegation = typed.clone().into_opaque();
+    let err = untyped.try_into_typed::<OtherCapability>().unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
     let err = Delegation::<OtherCapability>::decode(&typed.encode()).unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
@@ -291,8 +291,8 @@ fn two_link_chain_invocation() {
     let opaque_link = link.into_opaque();
     // Opaque delegations are checked by parsing them into typed delegations first.
     let parsed_chain = [
-        opaque_root.parse::<Rpc>().unwrap(),
-        opaque_link.parse::<Rpc>().unwrap(),
+        opaque_root.try_into_typed::<Rpc>().unwrap(),
+        opaque_link.try_into_typed::<Rpc>().unwrap(),
     ];
     let refs = [&parsed_chain[0], &parsed_chain[1]];
     authorizer

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     Authorizer, Capability, DecodeError, Delegation, Expires, InvocationError, OpaqueDelegation,
+    BASE32_LOWER_NOPAD,
 };
 
 /// An example capability type for testing.
@@ -110,13 +111,10 @@ fn string_snapshots() {
     let opaque = OpaqueDelegation::decode_string(V2_STRING).unwrap();
     assert_eq!(opaque, v2.into_opaque());
 
-    let mut bytes = data_encoding::BASE32_NOPAD
-        .decode(V2_STRING.to_ascii_uppercase().as_bytes())
-        .unwrap();
+    let mut bytes = BASE32_LOWER_NOPAD.decode(V2_STRING.as_bytes()).unwrap();
     let n = bytes.len();
     bytes[n - 1] ^= 1;
-    let mut tampered = data_encoding::BASE32_NOPAD.encode(&bytes);
-    tampered.make_ascii_lowercase();
+    let tampered = BASE32_LOWER_NOPAD.encode(&bytes);
     let err = Delegation::<Rpc>::decode_string(&tampered).unwrap_err();
     assert_matches!(err, DecodeError::InvalidSignature { .. });
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -275,7 +275,7 @@ fn two_link_chain_invocation() {
     let err = authorizer
         .check_invocation_from_at(now, key(3).verifying_key(), Rpc::Read, &chain)
         .unwrap_err();
-    assert_matches!(&err, InvocationError::WrongInvoker { invoker, chain_end, .. }
+    assert_matches!(&err, InvocationError::InvokerMismatch { invoker, chain_end, .. }
         if invoker == &key(3).verifying_key() && chain_end == &bob.verifying_key());
     let late = SystemTime::UNIX_EPOCH + Duration::from_secs(4_102_444_801);
     let err = authorizer
@@ -339,7 +339,7 @@ fn subject_must_be_the_authorizer() {
     let err = authorizer
         .check_invocation_from(alice.verifying_key(), Rpc::Read, &[&foreign_grant])
         .unwrap_err();
-    assert_matches!(&err, InvocationError::WrongCapabilityOwner { authorizer, .. }
+    assert_matches!(&err, InvocationError::CapabilityOwnerMismatch { authorizer, .. }
         if authorizer == &service.verifying_key());
 }
 
@@ -353,6 +353,6 @@ fn owner_needs_no_chain() {
     let err = authorizer
         .check_invocation_from::<Rpc>(key(1).verifying_key(), Rpc::Read, &[])
         .unwrap_err();
-    assert_matches!(&err, InvocationError::WrongInvoker { invoker, chain_end, .. }
+    assert_matches!(&err, InvocationError::InvokerMismatch { invoker, chain_end, .. }
         if invoker == &key(1).verifying_key() && chain_end == &service.verifying_key());
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,10 +53,10 @@ const V2_POSTCARD: &str = "
     3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29 // issuer: key(0)
     8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c // audience: key(1)
     00                                                               // capability origin: issuer
-    01 80ae99a40f                                                    // valid until: at 4102444800
+    01 fbf3855508                                                    // valid until: at 4102444800
     01 01                                                            // capability: 1 byte, Rpc::ReadWrite
-    83461886f14cdfa8b2d60eaab3ce00098761aa2bbf8dd028820fd54211bf2cca // signature (v2 DST)
-    ccfc635242760b1c1d0d1d1c98943556f725c1e2c7edcd94365660e5af929f06
+    fa8d3857bc29bc65c572a30f9bc603ad1b62a9fc4ebb37655e70b08f1d1e4037 // signature (v2 DST)
+    cf93f613d9cd0a76069dcefce0b92be3bc1d58852e85091eba1065882c824705
 ";
 
 const V2_NEVER: &str = "
@@ -70,7 +70,7 @@ const V2_NEVER: &str = "
     7e2d4944846a0689ad5c6f89f9cff7283836f78633dd95e896aaa73fd28a490e
 ";
 
-const V2_STRING: &str = "ai5wuj54z23killcuounaktpbvzwkmqvo4o6eq5ghlaerimllhnctcui4poxicprsx6vfwznhs5f24wkm4e36hmucin7g5eiag2a6324aaaybluzuqhqcamdiymin4km36ulfvqovkz44aajq5q2uk57rxicraqp2vbbdpzmzlgpyy2sij3awha5buorzgeugvlpojob4ld63tmugzlgbznpskpqm";
+const V2_STRING: &str = "ai5wuj54z23killcuounaktpbvzwkmqvo4o6eq5ghlaerimllhnctcui4poxicprsx6vfwznhs5f24wkm4e36hmucin7g5eiag2a6324aaa7x44fkueacap2ru4fppbjxrs4k4vdb6n4ma5ndnrkt7coxm3wkxtqwchr2hsag7hzh5qt3hgqu5qgtxhpzyfzfpr3yhkyquxikci6xiiglcbmqjdqk";
 
 #[test]
 fn wire_snapshots() {
@@ -98,7 +98,7 @@ fn wire_snapshots() {
     );
 
     let opaque = OpaqueDelegation::decode(&bytes).unwrap();
-    assert_eq!(&opaque, v2.opaque());
+    assert_eq!(opaque, v2.into_opaque());
 }
 
 #[test]
@@ -108,7 +108,7 @@ fn string_snapshots() {
     assert_eq!(Delegation::<Rpc>::decode_string(V2_STRING).unwrap(), v2);
 
     let opaque = OpaqueDelegation::decode_string(V2_STRING).unwrap();
-    assert_eq!(&opaque, v2.opaque());
+    assert_eq!(opaque, v2.into_opaque());
 
     let mut bytes = data_encoding::BASE32_NOPAD
         .decode(V2_STRING.to_ascii_uppercase().as_bytes())
@@ -130,11 +130,10 @@ fn serde_delegates_to_encode() {
     let postcard_expected = [vec![0x8a, 0x01], encoded.clone()].concat();
     assert_eq!(wire, postcard_expected);
     assert_eq!(postcard::from_bytes::<Delegation<Rpc>>(&wire).unwrap(), v2);
-    assert_eq!(postcard::to_stdvec(v2.opaque()).unwrap(), wire);
-    assert_eq!(
-        postcard::from_bytes::<OpaqueDelegation>(&wire).unwrap(),
-        *v2.opaque()
-    );
+    // The opaque form round-trips through the same wire encoding.
+    let opaque: OpaqueDelegation = v2.clone().into_opaque();
+    assert_eq!(opaque.encode(), v2.encode());
+    assert_eq!(OpaqueDelegation::decode(&v2.encode()).unwrap(), opaque);
 
     let mut cbor = Vec::new();
     ciborium::into_writer(&v2, &mut cbor).unwrap();
@@ -183,7 +182,7 @@ fn v2_decode_rejects_tampering() {
     let signature_start = padded.len() - SIGNATURE_LENGTH;
     padded.insert(signature_start, 0);
     let err = Delegation::<Rpc>::decode(&padded).unwrap_err();
-    assert_matches!(&err, DecodeError::Malformed { reason, .. } if reason.contains("signature length"));
+    assert_matches!(&err, DecodeError::Malformed { reason, .. } if reason.contains("canonical"));
 
     let mut versioned = good.clone();
     versioned[0] = 3;
@@ -194,37 +193,12 @@ fn v2_decode_rejects_tampering() {
     assert_matches!(&err, DecodeError::Malformed { reason, .. } if reason.contains("empty"));
 }
 
-/// A non-canonical v2 delegation with an overlong varint for the expiry time.
-const V2_NC_EXPIRY: &str = "
-    02                                                               // version: v2
-    3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29 // issuer: key(0)
-    8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c // audience: key(1)
-    00                                                               // capability origin: issuer
-    01 80ae99a48f00                                                  // valid until: at 4102444800 (overlong varint)
-    01 01                                                            // capability: 1 byte, Rpc::ReadWrite
-    83461886f14cdfa8b2d60eaab3ce00098761aa2bbf8dd028820fd54211bf2cca // signature (over the canonical form)
-    ccfc635242760b1c1d0d1d1c98943556f725c1e2c7edcd94365660e5af929f06
-";
-/// A non-canonical v2 delegation with an overlong varint for the capability length prefix.
-const V2_NC_CAP_LEN: &str = "
-    02                                                               // version: v2
-    3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29 // issuer: key(0)
-    8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c // audience: key(1)
-    00                                                               // capability origin: issuer
-    01 80ae99a40f                                                    // valid until: at 4102444800
-    81 00 01                                                         // capability: len 1 (overlong 0x81 0x00), Rpc::ReadWrite
-    83461886f14cdfa8b2d60eaab3ce00098761aa2bbf8dd028820fd54211bf2cca // signature (over the canonical form)
-    ccfc635242760b1c1d0d1d1c98943556f725c1e2c7edcd94365660e5af929f06
-";
-
-#[test]
-fn v2_rejects_non_canonical() {
-    assert!(Delegation::<Rpc>::decode(&hexdump(V2_POSTCARD)).is_ok());
-    for nc in [V2_NC_EXPIRY, V2_NC_CAP_LEN] {
-        let err = Delegation::<Rpc>::decode(&hexdump(nc)).unwrap_err();
-        assert_matches!(&err, DecodeError::Malformed { reason, .. } if reason.contains("canonical"));
-    }
-}
+// Canonicality is enforced by construction: the payload uses bijoux varints,
+// which are bijective with exactly one encoding per value. There is no overlong
+// (non-canonical) varint form to reject, so there is no equivalent of the
+// previous postcard-varint `V2_NC_*` rejection test. Any structural truncation
+// or padding is still rejected as `DecodeError::Malformed`, covered by
+// `v2_decode_rejects_tampering`.
 
 #[test]
 fn rejects_v1() {
@@ -242,12 +216,12 @@ fn opaque_roundtrip() {
     let typed = delegation();
     assert_eq!(typed.capability(), Rpc::ReadWrite);
 
-    let untyped: OpaqueDelegation = typed.clone().into();
-    let again = Delegation::<Rpc>::try_from(untyped.clone()).unwrap();
+    let untyped: OpaqueDelegation = typed.clone().into_opaque();
+    let again = untyped.clone().parse::<Rpc>().unwrap();
     assert_eq!(again, typed);
 
     let decoded = OpaqueDelegation::decode(&typed.encode()).unwrap();
-    let again = Delegation::<Rpc>::try_from(decoded).unwrap();
+    let again = decoded.parse::<Rpc>().unwrap();
     assert_eq!(again, typed);
 }
 
@@ -260,8 +234,8 @@ fn rejects_wrong_capability_type() {
     }
 
     let typed = delegation();
-    let untyped: OpaqueDelegation = typed.clone().into();
-    let err = Delegation::<OtherCapability>::try_from(untyped).unwrap_err();
+    let untyped: OpaqueDelegation = typed.clone().into_opaque();
+    let err = untyped.parse::<OtherCapability>().unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
     let err = Delegation::<OtherCapability>::decode(&typed.encode()).unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
@@ -315,12 +289,19 @@ fn two_link_chain_invocation() {
         }
     );
 
-    let opaque_chain = [root.opaque(), link.opaque()];
+    let opaque_root = root.into_opaque();
+    let opaque_link = link.into_opaque();
+    // Opaque delegations are checked by parsing them into typed delegations first.
+    let parsed_chain = [
+        opaque_root.parse::<Rpc>().unwrap(),
+        opaque_link.parse::<Rpc>().unwrap(),
+    ];
+    let refs = [&parsed_chain[0], &parsed_chain[1]];
     authorizer
-        .check_opaque_invocation_from_at(now, bob.verifying_key(), Rpc::Read, &opaque_chain)
+        .check_invocation_from_at(now, bob.verifying_key(), Rpc::Read, &refs)
         .unwrap();
     let err = authorizer
-        .check_opaque_invocation_from_at(now, bob.verifying_key(), Rpc::ReadWrite, &opaque_chain)
+        .check_invocation_from_at(now, bob.verifying_key(), Rpc::ReadWrite, &refs)
         .unwrap_err();
     assert_matches!(err, InvocationError::NotPermitted { .. });
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -87,7 +87,7 @@ fn wire_snapshots() {
     assert_eq!(v2.audience(), &key(1).verifying_key());
     assert_eq!(v2.expires(), &Expires::At(4_102_444_800));
     assert_eq!(v2.capability_owner(), &key(0).verifying_key());
-    assert_eq!(v2.capability(), Rpc::ReadWrite);
+    assert_eq!(*v2.capability(), Rpc::ReadWrite);
 
     let never = Delegation::issuing_builder(&key(0), key(1).verifying_key(), &Rpc::All)
         .sign(Expires::Never);
@@ -214,7 +214,7 @@ fn rejects_v1() {
 #[test]
 fn opaque_roundtrip() {
     let typed = delegation();
-    assert_eq!(typed.capability(), Rpc::ReadWrite);
+    assert_eq!(*typed.capability(), Rpc::ReadWrite);
 
     let untyped: OpaqueDelegation = typed.clone().into_opaque();
     let again = untyped.clone().parse::<Rpc>().unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -86,7 +86,7 @@ fn wire_snapshots() {
     assert_eq!(v2.issuer(), &key(0).verifying_key());
     assert_eq!(v2.audience(), &key(1).verifying_key());
     assert_eq!(v2.expires(), &Expires::At(4_102_444_800));
-    assert_eq!(v2.capability_issuer(), &key(0).verifying_key());
+    assert_eq!(v2.capability_owner(), &key(0).verifying_key());
     assert_eq!(v2.capability(), Rpc::ReadWrite);
 
     let never = Delegation::issuing_builder(&key(0), key(1).verifying_key(), &Rpc::All)
@@ -339,7 +339,7 @@ fn subject_must_be_the_authorizer() {
     let err = authorizer
         .check_invocation_from(alice.verifying_key(), Rpc::Read, &[&foreign_grant])
         .unwrap_err();
-    assert_matches!(&err, InvocationError::WrongCapabilityIssuer { authorizer, .. }
+    assert_matches!(&err, InvocationError::WrongCapabilityOwner { authorizer, .. }
         if authorizer == &service.verifying_key());
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -54,10 +54,10 @@ const V2_POSTCARD: &str = "
     3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29 // issuer: key(0)
     8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c // audience: key(1)
     00                                                               // capability origin: issuer
-    01 fbf3855508                                                    // valid until: at 4102444800
+    01 80ae99a40f                                                    // valid until: at 4102444800
     01 01                                                            // capability: 1 byte, Rpc::ReadWrite
-    fa8d3857bc29bc65c572a30f9bc603ad1b62a9fc4ebb37655e70b08f1d1e4037 // signature (v2 DST)
-    cf93f613d9cd0a76069dcefce0b92be3bc1d58852e85091eba1065882c824705
+    83461886f14cdfa8b2d60eaab3ce00098761aa2bbf8dd028820fd54211bf2cca // signature
+    ccfc635242760b1c1d0d1d1c98943556f725c1e2c7edcd94365660e5af929f06
 ";
 
 const V2_NEVER: &str = "
@@ -71,7 +71,7 @@ const V2_NEVER: &str = "
     7e2d4944846a0689ad5c6f89f9cff7283836f78633dd95e896aaa73fd28a490e
 ";
 
-const V2_STRING: &str = "ai5wuj54z23killcuounaktpbvzwkmqvo4o6eq5ghlaerimllhnctcui4poxicprsx6vfwznhs5f24wkm4e36hmucin7g5eiag2a6324aaa7x44fkueacap2ru4fppbjxrs4k4vdb6n4ma5ndnrkt7coxm3wkxtqwchr2hsag7hzh5qt3hgqu5qgtxhpzyfzfpr3yhkyquxikci6xiiglcbmqjdqk";
+const V2_STRING: &str = "ai5wuj54z23killcuounaktpbvzwkmqvo4o6eq5ghlaerimllhnctcui4poxicprsx6vfwznhs5f24wkm4e36hmucin7g5eiag2a6324aaaybluzuqhqcamdiymin4km36ulfvqovkz44aajq5q2uk57rxicraqp2vbbdpzmzlgpyy2sij3awha5buorzgeugvlpojob4ld63tmugzlgbznpskpqm";
 
 #[test]
 fn wire_snapshots() {
@@ -191,12 +191,25 @@ fn v2_decode_rejects_tampering() {
     assert_matches!(&err, DecodeError::Malformed { reason, .. } if reason.contains("empty"));
 }
 
-// Canonicality is enforced by construction: the payload uses bijoux varints,
-// which are bijective with exactly one encoding per value. There is no overlong
-// (non-canonical) varint form to reject, so there is no equivalent of the
-// previous postcard-varint `V2_NC_*` rejection test. Any structural truncation
-// or padding is still rejected as `DecodeError::Malformed`, covered by
-// `v2_decode_rejects_tampering`.
+#[test]
+fn rejects_non_canonical_varint() {
+    // The capability-origin field is at hex offset 130; replace its single-byte
+    // `00` (origin: issuer) with an overlong `80 00` (zero, continued). This is
+    // a valid postcard u64 but not canonical, so decode must reject it.
+    let good = delegation().encode();
+    let mut overlong = good.clone();
+    let origin_offset = 1 + 32 + 32;
+    overlong[origin_offset] = 0x80;
+    overlong.insert(origin_offset + 1, 0x00);
+    let err = Delegation::<Rpc>::decode(&overlong).unwrap_err();
+    assert_matches!(&err, DecodeError::Malformed { reason, .. } if reason.contains("non-canonical"));
+}
+
+// The delegation wire format encodes numeric fields as postcard varints.
+// postcard accepts overlong encodings (e.g. `0` as `0x80 0x00`), so `decode`
+// re-encodes and rejects non-canonical forms; see `rejects_non_canonical_varint`
+// below. Structural truncation or padding is rejected as `DecodeError::Malformed`,
+// covered by `v2_decode_rejects_tampering`.
 
 #[test]
 fn rejects_v1() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -142,10 +142,6 @@ fn serde_delegates_to_encode() {
         v2
     );
 
-    let mut cbor_array = Vec::new();
-    ciborium::into_writer(&encoded, &mut cbor_array).unwrap();
-    assert!(ciborium::from_reader::<Delegation<Rpc>, _>(&cbor_array[..]).is_err());
-
     let quoted = serde_json::to_string(&v2.encode_string()).unwrap();
     assert_eq!(serde_json::to_string(&v2).unwrap(), quoted);
     assert_eq!(


### PR DESCRIPTION
## Description

An attempt at reducing the crate API surface and some internal indirections and duplication.
- Switches from postcard to hand-rolled encoding, using postcard only for the varints
- Inlines `Payload` into `Delegation`
- Replaces `capability: Vec<u8>` with `capability: C` and removes `PhantomData<C>`
- Replaces the `OpaqueDelegation` newtype with a simple type alias `type OpaqueDelegation = Delegation<OpaqueCapability>`
- Renames `capability_issuer` to `capability_owner`
- Updates some code comments to use "principal" and "public key of principal" instead of "identity".
- Replaces `Serialize` and `Deserialize` in `trait Capability` with `CapabilityEncoding`, which can either be implemented manually or be auto-derived from serde.
- Reorders definitions

## Notes & open questions

Changes quite a bit - would be good to know if svc works well with this version as well, or otherwise figure out if there are holes.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
