### PR TITLE
fix: make sure serde roundtrips for different serde formats.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,12 +385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +493,22 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minicbor"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12b4033ffaa92fbf9df03df38d19324f52bad130dd223f811734a8006dd2d69"
+
+[[package]]
+name = "minicbor-serde"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7abdec9761edcb452764c68564ae4b77ec62f6c1a361aa68f5de15fd788c679"
+dependencies = [
+ "minicbor",
+ "serde",
+]
 
 [[package]]
 name = "n0-error"
@@ -630,13 +640,13 @@ dependencies = [
  "derive_more",
  "ed25519-dalek",
  "hex",
+ "minicbor-serde",
  "n0-error",
  "n0-future",
  "postcard",
  "ron",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "serde_json",
 ]
 
@@ -726,16 +736,6 @@ checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "postcard",
  "ron",
  "serde",
+ "serde_bytes",
  "serde_cbor",
  "serde_json",
 ]
@@ -715,6 +716,16 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,33 +97,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,12 +138,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -419,14 +386,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.7.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "hash32"
@@ -663,7 +625,6 @@ name = "rcan"
 version = "0.5.0"
 dependencies = [
  "assert_matches",
- "ciborium",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
@@ -674,6 +635,7 @@ dependencies = [
  "postcard",
  "ron",
  "serde",
+ "serde_cbor",
  "serde_json",
 ]
 
@@ -753,6 +715,16 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1144,26 +1116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ serde_bytes = "0.11"
 [dev-dependencies]
 assert_matches = "1.5.0"
 ron = "0.8"
-serde_cbor = "0.11"
+minicbor-serde = { version = "0.7", features = ["alloc"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ n0-future = "0.3.2"
 # delegation wire format's numeric fields.
 postcard = { version = "1.1.1", features = ["use-std"] }
 serde = { version = "1.0.217", features = ["derive"] }
+serde_bytes = "0.11"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ serde = { version = "1.0.217", features = ["derive"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ciborium = "0.2"
 ron = "0.8"
+serde_cbor = "0.11"
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,8 @@ impl<C: CapabilityEncoding> Serialize for Delegation<C> {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.encode_string())
         } else {
-            serializer.serialize_bytes(&self.encode())
+            let bytes = self.encode();
+            serde_bytes::Bytes::new(&bytes).serialize(serializer)
         }
     }
 }
@@ -220,42 +221,11 @@ impl<'de, C: CapabilityEncoding> Deserialize<'de> for Delegation<C> {
             let s = String::deserialize(deserializer)?;
             Self::decode_string(&s)
         } else {
-            let v = deserialize_byte_buf(deserializer)?;
-            Self::decode(&v)
+            let bytes = serde_bytes::ByteBuf::deserialize(deserializer)?;
+            Self::decode(&bytes)
         };
         delegation.map_err(D::Error::custom)
     }
-}
-
-fn deserialize_byte_buf<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    struct ByteBufVisitor;
-
-    impl<'de> serde::de::Visitor<'de> for ByteBufVisitor {
-        type Value = Vec<u8>;
-
-        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            formatter.write_str("a byte buffer")
-        }
-
-        fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            Ok(value.to_vec())
-        }
-
-        fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            Ok(value)
-        }
-    }
-
-    deserializer.deserialize_byte_buf(ByteBufVisitor)
 }
 
 /// A capability as raw, uninterpreted bytes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,11 +220,42 @@ impl<'de, C: CapabilityEncoding> Deserialize<'de> for Delegation<C> {
             let s = String::deserialize(deserializer)?;
             Self::decode_string(&s)
         } else {
-            let v = Vec::<u8>::deserialize(deserializer)?;
+            let v = deserialize_byte_buf(deserializer)?;
             Self::decode(&v)
         };
         delegation.map_err(D::Error::custom)
     }
+}
+
+fn deserialize_byte_buf<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct ByteBufVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for ByteBufVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a byte buffer")
+        }
+
+        fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value.to_vec())
+        }
+
+        fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value)
+        }
+    }
+
+    deserializer.deserialize_byte_buf(ByteBufVisitor)
 }
 
 /// A capability as raw, uninterpreted bytes.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -144,10 +144,10 @@ fn serde_delegates_to_encode() {
 }
 
 #[test]
-fn serde_cbor_roundtrip() {
+fn minicbor_serde_roundtrip() {
     let delegation = delegation();
-    let encoded = serde_cbor::to_vec(&delegation).unwrap();
-    let decoded = serde_cbor::from_slice::<Delegation<Rpc>>(&encoded).unwrap();
+    let encoded = minicbor_serde::to_vec(&delegation).unwrap();
+    let decoded = minicbor_serde::from_slice::<Delegation<Rpc>>(&encoded).unwrap();
     assert_eq!(decoded, delegation);
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -133,15 +133,6 @@ fn serde_delegates_to_encode() {
     assert_eq!(opaque.encode(), v2.encode());
     assert_eq!(Delegation::decode(&v2.encode()).unwrap(), opaque);
 
-    let mut cbor = Vec::new();
-    ciborium::into_writer(&v2, &mut cbor).unwrap();
-    let cbor_expected = [vec![0x58, 0x8a], encoded.clone()].concat();
-    assert_eq!(cbor, cbor_expected);
-    assert_eq!(
-        ciborium::from_reader::<Delegation<Rpc>, _>(&cbor[..]).unwrap(),
-        v2
-    );
-
     let quoted = serde_json::to_string(&v2.encode_string()).unwrap();
     assert_eq!(serde_json::to_string(&v2).unwrap(), quoted);
     assert_eq!(
@@ -150,6 +141,14 @@ fn serde_delegates_to_encode() {
     );
     assert_eq!(ron::to_string(&v2).unwrap(), quoted);
     assert_eq!(ron::from_str::<Delegation<Rpc>>(&quoted).unwrap(), v2);
+}
+
+#[test]
+fn serde_cbor_roundtrip() {
+    let delegation = delegation();
+    let encoded = serde_cbor::to_vec(&delegation).unwrap();
+    let decoded = serde_cbor::from_slice::<Delegation<Rpc>>(&encoded).unwrap();
+    assert_eq!(decoded, delegation);
 }
 
 #[test]


### PR DESCRIPTION
## Description

In general you can't roundtrip something written via `serialize_bytes` via Vec::<u8>::deserialize.

## Breaking Changes

None

## Notes & open questions

Q: ~~use serde_bytes instead of the custom visitor?~~
