### PR TITLE
feat: Don't require stable postcard encoding of C for decode/encode roundtrip

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,10 @@ pub struct Delegation<C = OpaqueCapability> {
     audience: VerifyingKey,
     capability_origin: CapabilityOrigin,
     valid_until: Expires,
-    capability: C,
     /// The exact capability representation used by the signed payload.
     capability_bytes: Vec<u8>,
     signature: Signature,
+    capability_type: std::marker::PhantomData<C>,
 }
 
 impl<C> Delegation<C> {
@@ -58,7 +58,6 @@ impl<C> Delegation<C> {
         audience: VerifyingKey,
         capability_origin: CapabilityOrigin,
         valid_until: Expires,
-        capability: C,
         capability_bytes: Vec<u8>,
         signature: Signature,
     ) -> Self {
@@ -67,9 +66,9 @@ impl<C> Delegation<C> {
             audience,
             capability_origin,
             valid_until,
-            capability,
             capability_bytes,
             signature,
+            capability_type: std::marker::PhantomData,
         }
     }
 
@@ -106,9 +105,20 @@ impl<C> Delegation<C> {
         &self.valid_until
     }
 
-    /// Returns the stored capability by reference.
-    pub fn capability(&self) -> &C {
-        &self.capability
+    /// Returns the encoded capability bytes from the signed payload.
+    pub fn capability_bytes(&self) -> &[u8] {
+        &self.capability_bytes
+    }
+
+    fn with_capability_type<D>(self) -> Delegation<D> {
+        Delegation::new(
+            self.issuer,
+            self.audience,
+            self.capability_origin,
+            self.valid_until,
+            self.capability_bytes,
+            self.signature,
+        )
     }
 }
 
@@ -116,16 +126,7 @@ impl<C> Delegation<C> {
     /// Turns this delegation into a `Delegation` with an opaque capability,
     /// preserving the capability bytes from the signed payload.
     pub fn into_opaque(self) -> Delegation {
-        let capability = OpaqueCapability(self.capability_bytes.clone());
-        Delegation::new(
-            self.issuer,
-            self.audience,
-            self.capability_origin,
-            self.valid_until,
-            capability,
-            self.capability_bytes,
-            self.signature,
-        )
+        self.with_capability_type()
     }
 
     /// Returns the delegation's byte encoding.
@@ -144,6 +145,12 @@ impl<C> Delegation<C> {
 }
 
 impl<C: CapabilityEncoding> Delegation<C> {
+    /// Decodes and returns the capability from the signed payload.
+    pub fn capability(&self) -> C {
+        C::decode(&self.capability_bytes)
+            .expect("capability was validated when the delegation was constructed")
+    }
+
     /// Decodes a delegation from its byte encoding, verifying the signature and
     /// decoding the capability as `C`.
     ///
@@ -294,16 +301,8 @@ impl Delegation {
     /// let back: Delegation<Cap> = opaque.try_into_typed().unwrap();
     /// ```
     pub fn try_into_typed<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
-        let capability = C::decode(&self.capability_bytes)?;
-        Ok(Delegation::new(
-            self.issuer,
-            self.audience,
-            self.capability_origin,
-            self.valid_until,
-            capability,
-            self.capability_bytes,
-            self.signature,
-        ))
+        C::decode(&self.capability_bytes)?;
+        Ok(self.with_capability_type())
     }
 }
 
@@ -370,7 +369,6 @@ impl<C: CapabilityEncoding> DelegationBuilder<'_, C> {
             self.audience,
             self.capability_origin,
             valid_until,
-            self.capability,
             capability_bytes,
             Signature::from_bytes(&[0u8; 64]),
         );
@@ -649,7 +647,6 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
         delegation.audience,
         delegation.capability_origin,
         delegation.valid_until,
-        delegation.capability,
         delegation.capability_bytes,
         signature,
     ))
@@ -675,7 +672,7 @@ fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, 
     let cap_len = usize::try_from(take_varint(buf)?)
         .map_err(|_| DecodeError::malformed("capability length overflow"))?;
     let cap_bytes = take_bytes(buf, cap_len)?;
-    let capability = C::decode(cap_bytes)?;
+    C::decode(cap_bytes)?;
     let capability_bytes = cap_bytes.to_vec();
 
     Ok(Delegation::new(
@@ -683,7 +680,6 @@ fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, 
         audience,
         capability_origin,
         valid_until,
-        capability,
         capability_bytes,
         Signature::from_bytes(&[0u8; 64]),
     ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ pub struct Delegation<C = OpaqueCapability> {
     capability_origin: CapabilityOrigin,
     valid_until: Expires,
     capability: C,
+    /// The exact capability representation used by the signed payload.
+    capability_bytes: Vec<u8>,
     signature: Signature,
 }
 
@@ -57,6 +59,7 @@ impl<C> Delegation<C> {
         capability_origin: CapabilityOrigin,
         valid_until: Expires,
         capability: C,
+        capability_bytes: Vec<u8>,
         signature: Signature,
     ) -> Self {
         Self {
@@ -65,6 +68,7 @@ impl<C> Delegation<C> {
             capability_origin,
             valid_until,
             capability,
+            capability_bytes,
             signature,
         }
     }
@@ -110,14 +114,16 @@ impl<C> Delegation<C> {
 
 impl<C: CapabilityEncoding> Delegation<C> {
     /// Turns this delegation into a `Delegation` with an opaque capability,
-    /// encoding the capability to bytes.
+    /// preserving the capability bytes from the signed payload.
     pub fn into_opaque(self) -> Delegation {
+        let capability = OpaqueCapability(self.capability_bytes.clone());
         Delegation::new(
             self.issuer,
             self.audience,
             self.capability_origin,
             self.valid_until,
-            OpaqueCapability(C::encode(&self.capability)),
+            capability,
+            self.capability_bytes,
             self.signature,
         )
     }
@@ -286,13 +292,14 @@ impl Delegation {
     /// let back: Delegation<Cap> = opaque.try_into_typed().unwrap();
     /// ```
     pub fn try_into_typed<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
-        let capability = C::decode(self.capability.as_bytes())?;
+        let capability = C::decode(&self.capability_bytes)?;
         Ok(Delegation::new(
             self.issuer,
             self.audience,
             self.capability_origin,
             self.valid_until,
             capability,
+            self.capability_bytes,
             self.signature,
         ))
     }
@@ -355,12 +362,14 @@ impl<C: CapabilityEncoding + Clone> DelegationBuilder<'_, C> {
     /// Signs the delegation, returning a [`Delegation<C>`] valid until
     /// `valid_until`.
     pub fn sign(self, valid_until: Expires) -> Delegation<C> {
+        let capability_bytes = C::encode(&self.capability);
         let delegation = Delegation::new(
             self.issuer.verifying_key(),
             self.audience,
             self.capability_origin,
             valid_until,
             self.capability,
+            capability_bytes,
             Signature::from_bytes(&[0u8; 64]),
         );
         let mut to_sign = DST.to_vec();
@@ -643,6 +652,7 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
         delegation.capability_origin,
         delegation.valid_until,
         delegation.capability,
+        delegation.capability_bytes,
         signature,
     ))
 }
@@ -668,6 +678,7 @@ fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, 
         .map_err(|_| DecodeError::malformed("capability length overflow"))?;
     let cap_bytes = take_bytes(buf, cap_len)?;
     let capability = C::decode(cap_bytes)?;
+    let capability_bytes = cap_bytes.to_vec();
 
     Ok(Delegation::new(
         issuer,
@@ -675,6 +686,7 @@ fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, 
         capability_origin,
         valid_until,
         capability,
+        capability_bytes,
         Signature::from_bytes(&[0u8; 64]),
     ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl<C> Delegation<C> {
     }
 }
 
-impl<C: CapabilityEncoding> Delegation<C> {
+impl<C> Delegation<C> {
     /// Turns this delegation into a `Delegation` with an opaque capability,
     /// preserving the capability bytes from the signed payload.
     pub fn into_opaque(self) -> Delegation {
@@ -141,7 +141,9 @@ impl<C: CapabilityEncoding> Delegation<C> {
     pub fn encode_string(&self) -> String {
         BASE32_LOWER_NOPAD.encode(&self.encode())
     }
+}
 
+impl<C: CapabilityEncoding> Delegation<C> {
     /// Decodes a delegation from its byte encoding, verifying the signature and
     /// decoding the capability as `C`.
     ///
@@ -208,7 +210,7 @@ impl<C: Clone> Delegation<C> {
 
 /// Serializes the delegation as its byte encoding, or as a base32 string when
 /// the format is human-readable. See [`Delegation::encode`].
-impl<C: CapabilityEncoding> Serialize for Delegation<C> {
+impl<C> Serialize for Delegation<C> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.encode_string())
@@ -358,7 +360,7 @@ pub struct DelegationBuilder<'s, C> {
     capability: C,
 }
 
-impl<C: CapabilityEncoding + Clone> DelegationBuilder<'_, C> {
+impl<C: CapabilityEncoding> DelegationBuilder<'_, C> {
     /// Signs the delegation, returning a [`Delegation<C>`] valid until
     /// `valid_until`.
     pub fn sign(self, valid_until: Expires) -> Delegation<C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,7 +600,7 @@ pub(crate) const BASE32_LOWER_NOPAD: data_encoding::Encoding = data_encoding_mac
     symbols: "abcdefghijklmnopqrstuvwxyz234567",
 );
 
-fn encode_body<C: CapabilityEncoding>(delegation: &Delegation<C>, out: &mut Vec<u8>) {
+fn encode_body<C>(delegation: &Delegation<C>, out: &mut Vec<u8>) {
     out.extend_from_slice(delegation.issuer.as_bytes());
     out.extend_from_slice(delegation.audience.as_bytes());
     match &delegation.capability_origin {
@@ -617,9 +617,8 @@ fn encode_body<C: CapabilityEncoding>(delegation: &Delegation<C>, out: &mut Vec<
             write_varint(*t, out);
         }
     }
-    let capability = C::encode(&delegation.capability);
-    write_varint(capability.len() as u64, out);
-    out.extend_from_slice(&capability);
+    write_varint(delegation.capability_bytes.len() as u64, out);
+    out.extend_from_slice(&delegation.capability_bytes);
 }
 
 fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C>, DecodeError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,10 +637,7 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
             .map_err(|_| DecodeError::malformed("invalid signature length"))?,
     );
     let mut to_verify = DST.to_vec();
-    encode_body::<C>(&delegation, &mut to_verify);
-    if to_verify[DST.len()..] != *body_bytes {
-        return Err(DecodeError::malformed("non canonical encoding of payload"));
-    }
+    to_verify.extend_from_slice(body_bytes);
     delegation
         .issuer
         .verify_strict(&to_verify, &signature)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub trait Capability: CapabilityEncoding {
 ///
 /// Bare `Delegation` (the default `C = OpaqueCapability`) holds the capability
 /// as raw bytes; turn it into a typed `Delegation<C>` with
-/// [`try_into_typed`](Delegation::try_into_typed).
+/// [`try_with_capability_type`](Delegation::try_with_capability_type).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Delegation<C = OpaqueCapability> {
     issuer: VerifyingKey,
@@ -110,7 +110,24 @@ impl<C> Delegation<C> {
         &self.capability_bytes
     }
 
-    fn with_capability_type<D>(self) -> Delegation<D> {
+    /// Validates the capability bytes as `D` and changes the capability type.
+    pub fn try_with_capability_type<D: CapabilityEncoding>(
+        self,
+    ) -> Result<Delegation<D>, DecodeError> {
+        D::decode(&self.capability_bytes)?;
+        Ok(Delegation::new(
+            self.issuer,
+            self.audience,
+            self.capability_origin,
+            self.valid_until,
+            self.capability_bytes,
+            self.signature,
+        ))
+    }
+
+    /// Turns this delegation into a `Delegation` with an opaque capability,
+    /// preserving the capability bytes from the signed payload.
+    pub fn into_opaque(self) -> Delegation {
         Delegation::new(
             self.issuer,
             self.audience,
@@ -119,14 +136,6 @@ impl<C> Delegation<C> {
             self.capability_bytes,
             self.signature,
         )
-    }
-}
-
-impl<C> Delegation<C> {
-    /// Turns this delegation into a `Delegation` with an opaque capability,
-    /// preserving the capability bytes from the signed payload.
-    pub fn into_opaque(self) -> Delegation {
-        self.with_capability_type()
     }
 
     /// Returns the delegation's byte encoding.
@@ -269,40 +278,6 @@ impl CapabilityEncoding for OpaqueCapability {
 impl Capability for OpaqueCapability {
     fn permits(&self, other: &Self) -> bool {
         self == other
-    }
-}
-
-impl Delegation {
-    /// Consumes this delegation and returns it with the capability interpreted
-    /// as `C`, yielding a typed [`Delegation<C>`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`DecodeError::WrongCapability`] if the bytes are not a valid
-    /// encoding of `C` (unless `C` is [`OpaqueCapability`], which accepts any
-    /// bytes).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ed25519_dalek::SigningKey;
-    /// use rcan::{Delegation, Expires};
-    /// use serde::{Deserialize, Serialize};
-    ///
-    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-    /// enum Cap {
-    ///     Read,
-    /// }
-    ///
-    /// let key = SigningKey::from_bytes(&[0u8; 32]);
-    /// let typed =
-    ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
-    /// let opaque = typed.into_opaque();
-    /// let back: Delegation<Cap> = opaque.try_into_typed().unwrap();
-    /// ```
-    pub fn try_into_typed<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
-        C::decode(&self.capability_bytes)?;
-        Ok(self.with_capability_type())
     }
 }
 
@@ -449,7 +424,8 @@ impl Authorizer {
     /// expiry against an explicit time instead of "now".
     ///
     /// Opaque delegations are not checked directly; parse them into a typed
-    /// delegation with [`try_into_typed`](Delegation::try_into_typed) first,
+    /// delegation with
+    /// [`try_with_capability_type`](Delegation::try_with_capability_type) first,
     /// then check them here.
     pub fn check_invocation_from_at<C: Capability>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,22 +595,21 @@ fn encode_body<C: CapabilityEncoding>(delegation: &Delegation<C>, out: &mut Vec<
     out.extend_from_slice(delegation.issuer.as_bytes());
     out.extend_from_slice(delegation.audience.as_bytes());
     match &delegation.capability_origin {
-        // `0u64`/`1u64` as varints
-        CapabilityOrigin::Issuer => out.extend_from_slice(&postcard::to_stdvec(&0u64).unwrap()),
+        CapabilityOrigin::Issuer => write_varint(0, out),
         CapabilityOrigin::Delegation(root) => {
-            out.extend_from_slice(&postcard::to_stdvec(&1u64).unwrap());
+            write_varint(1, out);
             out.extend_from_slice(root.as_bytes());
         }
     }
     match &delegation.valid_until {
-        Expires::Never => out.extend_from_slice(&postcard::to_stdvec(&0u64).unwrap()),
+        Expires::Never => write_varint(0, out),
         Expires::At(t) => {
-            out.extend_from_slice(&postcard::to_stdvec(&1u64).unwrap());
-            out.extend_from_slice(&postcard::to_stdvec(t).unwrap());
+            write_varint(1, out);
+            write_varint(*t, out);
         }
     }
     let capability = C::encode(&delegation.capability);
-    out.extend_from_slice(&postcard::to_stdvec(&(capability.len() as u64)).unwrap());
+    write_varint(capability.len() as u64, out);
     out.extend_from_slice(&capability);
 }
 
@@ -651,7 +650,7 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
 fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, DecodeError> {
     let issuer = take_key(buf)?;
     let audience = take_key(buf)?;
-    let capability_origin = match take_u64(buf)? {
+    let capability_origin = match take_varint(buf)? {
         0 => CapabilityOrigin::Issuer,
         1 => CapabilityOrigin::Delegation(take_key(buf)?),
         tag => {
@@ -660,12 +659,12 @@ fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, 
             )))
         }
     };
-    let valid_until = match take_u64(buf)? {
+    let valid_until = match take_varint(buf)? {
         0 => Expires::Never,
-        1 => Expires::At(take_u64(buf)?),
+        1 => Expires::At(take_varint(buf)?),
         tag => return Err(DecodeError::malformed(format!("unknown expires tag {tag}"))),
     };
-    let cap_len = usize::try_from(take_u64(buf)?)
+    let cap_len = usize::try_from(take_varint(buf)?)
         .map_err(|_| DecodeError::malformed("capability length overflow"))?;
     let cap_bytes = take_bytes(buf, cap_len)?;
     let capability = C::decode(cap_bytes)?;
@@ -701,17 +700,29 @@ fn take_key(buf: &mut &[u8]) -> Result<VerifyingKey, DecodeError> {
     VerifyingKey::from_bytes(bytes).map_err(|_| DecodeError::malformed("invalid key"))
 }
 
-fn take_u64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
+/// Appends postcard's canonical varint encoding of `value` to `out`.
+fn write_varint(value: u64, out: &mut Vec<u8>) {
+    let mut buf = [0u8; 10];
+    let encoded = postcard::to_slice(&value, &mut buf).expect("u64 fits in ten bytes");
+    out.extend_from_slice(encoded);
+}
+
+/// Takes one canonically postcard-encoded `u64` from the front of `buf`.
+///
+/// The input slice is advanced only on success. This rejects truncated,
+/// overflowing, and non-minimal encodings without heap allocation.
+fn take_varint(buf: &mut &[u8]) -> Result<u64, DecodeError> {
     let before = *buf;
-    let (value, rest) = postcard::take_from_bytes::<u64>(buf)
-        .map_err(|e| DecodeError::malformed(format!("invalid varint: {e}")))?;
+    let (value, rest) = postcard::take_from_bytes::<u64>(before)
+        .map_err(|error| DecodeError::malformed(format!("invalid varint: {error}")))?;
     let consumed = &before[..before.len() - rest.len()];
-    // postcard allows overlong varints (e.g. 0 as `0x80 0x00`); the delegation
-    // body requires the canonical encoding, so re-encode and compare.
-    let canonical = postcard::to_stdvec(&value).expect("u64 serializes");
-    if consumed != &canonical[..] {
+
+    let mut canonical_buf = [0u8; 10];
+    let canonical = postcard::to_slice(&value, &mut canonical_buf).expect("u64 fits in ten bytes");
+    if consumed != canonical {
         return Err(DecodeError::malformed("non-canonical varint"));
     }
+
     *buf = rest;
     Ok(value)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub trait Capability: CapabilityEncoding {
 ///
 /// Bare `Delegation` (the default `C = OpaqueCapability`) holds the capability
 /// as raw bytes; turn it into a typed `Delegation<C>` with
-/// [`try_with_capability_type`](Delegation::try_with_capability_type).
+/// [`try_into_typed`](Delegation::try_into_typed).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Delegation<C = OpaqueCapability> {
     issuer: VerifyingKey,
@@ -110,24 +110,7 @@ impl<C> Delegation<C> {
         &self.capability_bytes
     }
 
-    /// Validates the capability bytes as `D` and changes the capability type.
-    pub fn try_with_capability_type<D: CapabilityEncoding>(
-        self,
-    ) -> Result<Delegation<D>, DecodeError> {
-        D::decode(&self.capability_bytes)?;
-        Ok(Delegation::new(
-            self.issuer,
-            self.audience,
-            self.capability_origin,
-            self.valid_until,
-            self.capability_bytes,
-            self.signature,
-        ))
-    }
-
-    /// Turns this delegation into a `Delegation` with an opaque capability,
-    /// preserving the capability bytes from the signed payload.
-    pub fn into_opaque(self) -> Delegation {
+    fn with_capability_type<D>(self) -> Delegation<D> {
         Delegation::new(
             self.issuer,
             self.audience,
@@ -136,6 +119,14 @@ impl<C> Delegation<C> {
             self.capability_bytes,
             self.signature,
         )
+    }
+}
+
+impl<C> Delegation<C> {
+    /// Turns this delegation into a `Delegation` with an opaque capability,
+    /// preserving the capability bytes from the signed payload.
+    pub fn into_opaque(self) -> Delegation {
+        self.with_capability_type()
     }
 
     /// Returns the delegation's byte encoding.
@@ -282,6 +273,40 @@ impl Capability for OpaqueCapability {
     }
 }
 
+impl Delegation {
+    /// Consumes this delegation and returns it with the capability interpreted
+    /// as `C`, yielding a typed [`Delegation<C>`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError::WrongCapability`] if the bytes are not a valid
+    /// encoding of `C` (unless `C` is [`OpaqueCapability`], which accepts any
+    /// bytes).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ed25519_dalek::SigningKey;
+    /// use rcan::{Delegation, Expires};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// enum Cap {
+    ///     Read,
+    /// }
+    ///
+    /// let key = SigningKey::from_bytes(&[0u8; 32]);
+    /// let typed =
+    ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
+    /// let opaque = typed.into_opaque();
+    /// let back: Delegation<Cap> = opaque.try_into_typed().unwrap();
+    /// ```
+    pub fn try_into_typed<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
+        C::decode(&self.capability_bytes)?;
+        Ok(self.with_capability_type())
+    }
+}
+
 /// Where a delegated capability comes from.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CapabilityOrigin {
@@ -425,8 +450,7 @@ impl Authorizer {
     /// expiry against an explicit time instead of "now".
     ///
     /// Opaque delegations are not checked directly; parse them into a typed
-    /// delegation with
-    /// [`try_with_capability_type`](Delegation::try_with_capability_type) first,
+    /// delegation with [`try_into_typed`](Delegation::try_into_typed) first,
     /// then check them here.
     pub fn check_invocation_from_at<C: Capability>(
         &self,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -88,7 +88,7 @@ fn wire_snapshots() {
     assert_eq!(v2.audience(), &key(1).verifying_key());
     assert_eq!(v2.expires(), &Expires::At(4_102_444_800));
     assert_eq!(v2.capability_owner(), &key(0).verifying_key());
-    assert_eq!(*v2.capability(), Rpc::ReadWrite);
+    assert_eq!(v2.capability(), Rpc::ReadWrite);
 
     let never = Delegation::issuing_builder(&key(0), key(1).verifying_key(), &Rpc::All)
         .sign(Expires::Never);
@@ -219,7 +219,7 @@ fn rejects_v1() {
 #[test]
 fn opaque_roundtrip() {
     let typed = delegation();
-    assert_eq!(*typed.capability(), Rpc::ReadWrite);
+    assert_eq!(typed.capability(), Rpc::ReadWrite);
 
     let untyped: Delegation = typed.clone().into_opaque();
     let again = untyped.clone().try_into_typed::<Rpc>().unwrap();
@@ -261,7 +261,7 @@ fn hashmap_capability_roundtrips() {
     let encoded = delegation.encode();
     let decoded = Delegation::<std::collections::HashMap<u64, u64>>::decode(&encoded).unwrap();
 
-    assert_eq!(decoded.capability(), &capability);
+    assert_eq!(decoded.capability(), capability);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -221,11 +221,11 @@ fn opaque_roundtrip() {
     assert_eq!(typed.capability(), Rpc::ReadWrite);
 
     let untyped: Delegation = typed.clone().into_opaque();
-    let again = untyped.clone().try_with_capability_type::<Rpc>().unwrap();
+    let again = untyped.clone().try_into_typed::<Rpc>().unwrap();
     assert_eq!(again, typed);
 
-    let decoded: Delegation = Delegation::decode(&typed.encode()).unwrap();
-    let again = decoded.try_with_capability_type::<Rpc>().unwrap();
+    let decoded = Delegation::decode(&typed.encode()).unwrap();
+    let again = decoded.try_into_typed::<Rpc>().unwrap();
     assert_eq!(again, typed);
 }
 
@@ -239,9 +239,7 @@ fn rejects_wrong_capability_type() {
 
     let typed = delegation();
     let untyped: Delegation = typed.clone().into_opaque();
-    let err = untyped
-        .try_with_capability_type::<OtherCapability>()
-        .unwrap_err();
+    let err = untyped.try_into_typed::<OtherCapability>().unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
     let err = Delegation::<OtherCapability>::decode(&typed.encode()).unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
@@ -314,8 +312,8 @@ fn two_link_chain_invocation() {
     let opaque_link = link.into_opaque();
     // Opaque delegations are checked by parsing them into typed delegations first.
     let parsed_chain = [
-        opaque_root.try_with_capability_type::<Rpc>().unwrap(),
-        opaque_link.try_with_capability_type::<Rpc>().unwrap(),
+        opaque_root.try_into_typed::<Rpc>().unwrap(),
+        opaque_link.try_into_typed::<Rpc>().unwrap(),
     ];
     let refs = [&parsed_chain[0], &parsed_chain[1]];
     authorizer

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -201,11 +201,9 @@ fn rejects_non_canonical_varint() {
     assert_matches!(&err, DecodeError::Malformed { reason, .. } if reason.contains("non-canonical"));
 }
 
-// The delegation wire format encodes numeric fields as postcard varints.
-// postcard accepts overlong encodings (e.g. `0` as `0x80 0x00`), so `decode`
-// re-encodes and rejects non-canonical forms; see `rejects_non_canonical_varint`
-// below. Structural truncation or padding is rejected as `DecodeError::Malformed`,
-// covered by `v2_decode_rejects_tampering`.
+// The delegation wire format encodes numeric fields as canonical postcard
+// varints. Structural truncation or padding is rejected as
+// `DecodeError::Malformed`, covered by `v2_decode_rejects_tampering`.
 
 #[test]
 fn rejects_v1() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -222,11 +222,11 @@ fn opaque_roundtrip() {
     assert_eq!(typed.capability(), Rpc::ReadWrite);
 
     let untyped: Delegation = typed.clone().into_opaque();
-    let again = untyped.clone().try_into_typed::<Rpc>().unwrap();
+    let again = untyped.clone().try_with_capability_type::<Rpc>().unwrap();
     assert_eq!(again, typed);
 
-    let decoded = Delegation::decode(&typed.encode()).unwrap();
-    let again = decoded.try_into_typed::<Rpc>().unwrap();
+    let decoded: Delegation = Delegation::decode(&typed.encode()).unwrap();
+    let again = decoded.try_with_capability_type::<Rpc>().unwrap();
     assert_eq!(again, typed);
 }
 
@@ -240,7 +240,9 @@ fn rejects_wrong_capability_type() {
 
     let typed = delegation();
     let untyped: Delegation = typed.clone().into_opaque();
-    let err = untyped.try_into_typed::<OtherCapability>().unwrap_err();
+    let err = untyped
+        .try_with_capability_type::<OtherCapability>()
+        .unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
     let err = Delegation::<OtherCapability>::decode(&typed.encode()).unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
@@ -313,8 +315,8 @@ fn two_link_chain_invocation() {
     let opaque_link = link.into_opaque();
     // Opaque delegations are checked by parsing them into typed delegations first.
     let parsed_chain = [
-        opaque_root.try_into_typed::<Rpc>().unwrap(),
-        opaque_link.try_into_typed::<Rpc>().unwrap(),
+        opaque_root.try_with_capability_type::<Rpc>().unwrap(),
+        opaque_link.try_with_capability_type::<Rpc>().unwrap(),
     ];
     let refs = [&parsed_chain[0], &parsed_chain[1]];
     authorizer

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -252,6 +252,21 @@ fn rejects_wrong_capability_type() {
 }
 
 #[test]
+fn hashmap_capability_roundtrips() {
+    let issuer = key(0);
+    let audience = key(1).verifying_key();
+    let capability: std::collections::HashMap<u64, u64> =
+        (0..64).map(|value| (value, value * 2)).collect();
+
+    let delegation =
+        Delegation::issuing_builder(&issuer, audience, &capability).sign(Expires::Never);
+    let encoded = delegation.encode();
+    let decoded = Delegation::<std::collections::HashMap<u64, u64>>::decode(&encoded).unwrap();
+
+    assert_eq!(decoded.capability(), &capability);
+}
+
+#[test]
 fn two_link_chain_invocation() {
     let service = key(0);
     let alice = key(1);


### PR DESCRIPTION
## Description

Currently we require C to have a stable postcard encoding. We do a quick re-encode test in decode and produce an error, but that gives us the weird situation that there are some C for which encode works but decode doesn't.

By keeping the actual signed bytes (currently *in addition* to C itself) we can make sure that everything that is decodable can also be reencoded, and can just drop the requirement for C that it has a stable serialization (several std types such as HashMap don't have it, and we have a default impl for *all* C that implement Serialize/Deserialize)

## Breaking Changes

None

## Notes & open questions

Note: we could also remove C to avoid storing the data twice, and deser on demand.