### PR TITLE
feat: Rename try_into_typed to try_with_capability_type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub trait Capability: CapabilityEncoding {
 ///
 /// Bare `Delegation` (the default `C = OpaqueCapability`) holds the capability
 /// as raw bytes; turn it into a typed `Delegation<C>` with
-/// [`try_into_typed`](Delegation::try_into_typed).
+/// [`try_with_capability_type`](Delegation::try_with_capability_type).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Delegation<C = OpaqueCapability> {
     issuer: VerifyingKey,
@@ -119,6 +119,40 @@ impl<C> Delegation<C> {
             self.capability_bytes,
             self.signature,
         )
+    }
+
+    /// Consumes this delegation and returns it with the capability interpreted
+    /// as `D`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError::WrongCapability`] if the bytes are not a valid
+    /// encoding of `D` (unless `D` is [`OpaqueCapability`], which accepts any
+    /// bytes).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ed25519_dalek::SigningKey;
+    /// use rcan::{Delegation, Expires};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// enum Cap {
+    ///     Read,
+    /// }
+    ///
+    /// let key = SigningKey::from_bytes(&[0u8; 32]);
+    /// let typed =
+    ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
+    /// let opaque = typed.into_opaque();
+    /// let back: Delegation<Cap> = opaque.try_with_capability_type().unwrap();
+    /// ```
+    pub fn try_with_capability_type<D: CapabilityEncoding>(
+        self,
+    ) -> Result<Delegation<D>, DecodeError> {
+        D::decode(&self.capability_bytes)?;
+        Ok(self.with_capability_type())
     }
 }
 
@@ -273,40 +307,6 @@ impl Capability for OpaqueCapability {
     }
 }
 
-impl Delegation {
-    /// Consumes this delegation and returns it with the capability interpreted
-    /// as `C`, yielding a typed [`Delegation<C>`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`DecodeError::WrongCapability`] if the bytes are not a valid
-    /// encoding of `C` (unless `C` is [`OpaqueCapability`], which accepts any
-    /// bytes).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ed25519_dalek::SigningKey;
-    /// use rcan::{Delegation, Expires};
-    /// use serde::{Deserialize, Serialize};
-    ///
-    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-    /// enum Cap {
-    ///     Read,
-    /// }
-    ///
-    /// let key = SigningKey::from_bytes(&[0u8; 32]);
-    /// let typed =
-    ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
-    /// let opaque = typed.into_opaque();
-    /// let back: Delegation<Cap> = opaque.try_into_typed().unwrap();
-    /// ```
-    pub fn try_into_typed<C: CapabilityEncoding>(self) -> Result<Delegation<C>, DecodeError> {
-        C::decode(&self.capability_bytes)?;
-        Ok(self.with_capability_type())
-    }
-}
-
 /// Where a delegated capability comes from.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CapabilityOrigin {
@@ -450,7 +450,8 @@ impl Authorizer {
     /// expiry against an explicit time instead of "now".
     ///
     /// Opaque delegations are not checked directly; parse them into a typed
-    /// delegation with [`try_into_typed`](Delegation::try_into_typed) first,
+    /// delegation with
+    /// [`try_with_capability_type`](Delegation::try_with_capability_type) first,
     /// then check them here.
     pub fn check_invocation_from_at<C: Capability>(
         &self,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -221,11 +221,11 @@ fn opaque_roundtrip() {
     assert_eq!(typed.capability(), Rpc::ReadWrite);
 
     let untyped: Delegation = typed.clone().into_opaque();
-    let again = untyped.clone().try_into_typed::<Rpc>().unwrap();
+    let again = untyped.clone().try_with_capability_type::<Rpc>().unwrap();
     assert_eq!(again, typed);
 
-    let decoded = Delegation::decode(&typed.encode()).unwrap();
-    let again = decoded.try_into_typed::<Rpc>().unwrap();
+    let decoded: Delegation = Delegation::decode(&typed.encode()).unwrap();
+    let again = decoded.try_with_capability_type::<Rpc>().unwrap();
     assert_eq!(again, typed);
 }
 
@@ -239,7 +239,14 @@ fn rejects_wrong_capability_type() {
 
     let typed = delegation();
     let untyped: Delegation = typed.clone().into_opaque();
-    let err = untyped.try_into_typed::<OtherCapability>().unwrap_err();
+    let err = typed
+        .clone()
+        .try_with_capability_type::<OtherCapability>()
+        .unwrap_err();
+    assert_matches!(err, DecodeError::WrongCapability { .. });
+    let err = untyped
+        .try_with_capability_type::<OtherCapability>()
+        .unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
     let err = Delegation::<OtherCapability>::decode(&typed.encode()).unwrap_err();
     assert_matches!(err, DecodeError::WrongCapability { .. });
@@ -312,8 +319,8 @@ fn two_link_chain_invocation() {
     let opaque_link = link.into_opaque();
     // Opaque delegations are checked by parsing them into typed delegations first.
     let parsed_chain = [
-        opaque_root.try_into_typed::<Rpc>().unwrap(),
-        opaque_link.try_into_typed::<Rpc>().unwrap(),
+        opaque_root.try_with_capability_type::<Rpc>().unwrap(),
+        opaque_link.try_with_capability_type::<Rpc>().unwrap(),
     ];
     let refs = [&parsed_chain[0], &parsed_chain[1]];
     authorizer


### PR DESCRIPTION
## Description

Rename try_into_typed to try_with_capability_type and have it on all delegations. This allows you to cast a `Delegation<C>` to `Delegation<D>`, not just a `Delegation` to `Delegation<C>`.

You can of course do the same currently by casting to opaque and then doing try_into_typed, but I find it nicer if all fns are on Delegation<C>

## Breaking Changes

Rename of try_into_typed to try_with_capability_type

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
