### PR TITLE
refactor: Use smallvec in a number of places to prevent allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ n0-future = "0.3.2"
 postcard = { version = "1.1.1", features = ["use-std"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_bytes = "0.11"
+smallvec = { version = "1", features = ["const_generics"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,21 +132,27 @@ impl<C> Delegation<C> {
 
     /// Returns the delegation's byte encoding.
     pub fn encode(&self) -> Vec<u8> {
-        self.encode_wire().into_vec()
+        let mut bytes = SmallVec::<[u8; 192]>::new();
+        self.encode_into(&mut bytes);
+        bytes.into_vec()
+    }
+
+    /// Appends the delegation's byte encoding to `out`.
+    ///
+    /// This is identical to [`encode`](Delegation::encode) but avoids an
+    /// allocation when the caller can provide a buffer.
+    pub fn encode_into(&self, out: &mut impl Extend<u8>) {
+        out.extend(std::iter::once(2));
+        encode_body(self, out);
+        out.extend(self.signature.to_bytes());
     }
 
     /// Returns a lowercase base32 string of the delegation's byte encoding,
     /// useful for compact, printable representations.
     pub fn encode_string(&self) -> String {
-        BASE32_LOWER_NOPAD.encode(&self.encode_wire())
-    }
-
-    fn encode_wire(&self) -> SmallVec<[u8; 192]> {
-        let mut bytes = SmallVec::new();
-        bytes.push(2);
-        encode_body(self, &mut bytes);
-        bytes.extend_from_slice(&self.signature.to_bytes());
-        bytes
+        let mut bytes = SmallVec::<[u8; 192]>::new();
+        self.encode_into(&mut bytes);
+        BASE32_LOWER_NOPAD.encode(&bytes)
     }
 }
 
@@ -228,13 +234,14 @@ impl<C: Clone> Delegation<C> {
 }
 
 /// Serializes the delegation as its byte encoding, or as a base32 string when
-/// the format is human-readable. See [`Delegation::encode`].
+/// the format is human-readable. See [`Delegation::encode_into`].
 impl<C> Serialize for Delegation<C> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.encode_string())
         } else {
-            let bytes = self.encode_wire();
+            let mut bytes = SmallVec::<[u8; 192]>::new();
+            self.encode_into(&mut bytes);
             serde_bytes::Bytes::new(&bytes).serialize(serializer)
         }
     }
@@ -623,14 +630,14 @@ pub(crate) const BASE32_LOWER_NOPAD: data_encoding::Encoding = data_encoding_mac
     symbols: "abcdefghijklmnopqrstuvwxyz234567",
 );
 
-fn encode_body<C>(delegation: &Delegation<C>, out: &mut SmallVec<[u8; 192]>) {
-    out.extend_from_slice(delegation.issuer.as_bytes());
-    out.extend_from_slice(delegation.audience.as_bytes());
+fn encode_body<C>(delegation: &Delegation<C>, out: &mut impl Extend<u8>) {
+    out.extend(delegation.issuer.as_bytes().iter().copied());
+    out.extend(delegation.audience.as_bytes().iter().copied());
     match &delegation.capability_origin {
         CapabilityOrigin::Issuer => write_varint(0, out),
         CapabilityOrigin::Delegation(root) => {
             write_varint(1, out);
-            out.extend_from_slice(root.as_bytes());
+            out.extend(root.as_bytes().iter().copied());
         }
     }
     match &delegation.valid_until {
@@ -641,7 +648,7 @@ fn encode_body<C>(delegation: &Delegation<C>, out: &mut SmallVec<[u8; 192]>) {
         }
     }
     write_varint(delegation.capability_bytes.len() as u64, out);
-    out.extend_from_slice(&delegation.capability_bytes);
+    out.extend(delegation.capability_bytes.iter().copied());
 }
 
 fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C>, DecodeError> {
@@ -730,10 +737,10 @@ fn take_key(buf: &mut &[u8]) -> Result<VerifyingKey, DecodeError> {
 }
 
 /// Appends postcard's canonical varint encoding of `value` to `out`.
-fn write_varint(value: u64, out: &mut SmallVec<[u8; 192]>) {
+fn write_varint(value: u64, out: &mut impl Extend<u8>) {
     let mut buf = [0u8; 10];
     let encoded = postcard::to_slice(&value, &mut buf).expect("u64 fits in ten bytes");
-    out.extend_from_slice(encoded);
+    out.extend(encoded.iter().copied());
 }
 
 /// Takes one canonically postcard-encoded `u64` from the front of `buf`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,6 @@ use smallvec::SmallVec;
 #[cfg(test)]
 mod tests;
 
-type WireBytes = SmallVec<[u8; 192]>;
-
 /// A grantable capability.
 ///
 /// Implement this for your own capability type, typically an enum of the
@@ -143,8 +141,8 @@ impl<C> Delegation<C> {
         BASE32_LOWER_NOPAD.encode(&self.encode_wire())
     }
 
-    fn encode_wire(&self) -> WireBytes {
-        let mut bytes = WireBytes::new();
+    fn encode_wire(&self) -> SmallVec<[u8; 192]> {
+        let mut bytes = SmallVec::new();
         bytes.push(2);
         encode_body(self, &mut bytes);
         bytes.extend_from_slice(&self.signature.to_bytes());
@@ -186,7 +184,7 @@ impl<C: CapabilityEncoding> Delegation<C> {
         let len = BASE32_LOWER_NOPAD
             .decode_len(s.len())
             .map_err(DecodeError::malformed)?;
-        let mut bytes = WireBytes::new();
+        let mut bytes = SmallVec::<[u8; 192]>::new();
         bytes.resize(len, 0);
         let len = BASE32_LOWER_NOPAD
             .decode_mut(s.as_bytes(), &mut bytes)
@@ -272,8 +270,8 @@ impl OpaqueCapability {
 }
 
 impl CapabilityEncoding for OpaqueCapability {
-    fn encode(&self) -> Vec<u8> {
-        self.0.to_vec()
+    fn encode_into(&self, out: &mut impl Extend<u8>) {
+        out.extend(self.0.iter().copied());
     }
 
     fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
@@ -378,7 +376,8 @@ impl<C: CapabilityEncoding> DelegationBuilder<'_, C> {
     /// Signs the delegation, returning a [`Delegation<C>`] valid until
     /// `valid_until`.
     pub fn sign(self, valid_until: Expires) -> Delegation<C> {
-        let capability_bytes: SmallVec<[u8; 32]> = C::encode(&self.capability).into();
+        let mut capability_bytes = SmallVec::<[u8; 32]>::new();
+        self.capability.encode_into(&mut capability_bytes);
         let delegation = Delegation::new(
             self.issuer.verifying_key(),
             self.audience,
@@ -387,7 +386,7 @@ impl<C: CapabilityEncoding> DelegationBuilder<'_, C> {
             capability_bytes,
             Signature::from_bytes(&[0u8; 64]),
         );
-        let mut to_sign = WireBytes::from_slice(DST);
+        let mut to_sign = SmallVec::<[u8; 192]>::from_slice(DST);
         encode_body(&delegation, &mut to_sign);
         let signature = self.issuer.sign(&to_sign);
         Delegation {
@@ -514,8 +513,9 @@ impl Authorizer {
 /// implement this yourself: any [`Serialize`] + [`Deserialize`] type is
 /// supported automatically.
 pub trait CapabilityEncoding {
-    /// Returns the bytes this capability is represented as inside a delegation.
-    fn encode(&self) -> Vec<u8>;
+    /// Appends the bytes representing this capability inside a delegation to
+    /// `out`.
+    fn encode_into(&self, out: &mut impl Extend<u8>);
 
     /// Decodes a capability from its bytes.
     ///
@@ -528,9 +528,17 @@ pub trait CapabilityEncoding {
         Self: Sized;
 }
 
+struct ExtendRef<'a, T>(&'a mut T);
+
+impl<T: Extend<u8>> Extend<u8> for ExtendRef<'_, T> {
+    fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
+
 impl<T: Serialize + DeserializeOwned> CapabilityEncoding for T {
-    fn encode(&self) -> Vec<u8> {
-        postcard::to_stdvec(self).expect("capability serializes")
+    fn encode_into(&self, out: &mut impl Extend<u8>) {
+        postcard::to_extend(self, ExtendRef(out)).expect("capability serializes");
     }
 
     fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
@@ -615,7 +623,7 @@ pub(crate) const BASE32_LOWER_NOPAD: data_encoding::Encoding = data_encoding_mac
     symbols: "abcdefghijklmnopqrstuvwxyz234567",
 );
 
-fn encode_body<C>(delegation: &Delegation<C>, out: &mut WireBytes) {
+fn encode_body<C>(delegation: &Delegation<C>, out: &mut SmallVec<[u8; 192]>) {
     out.extend_from_slice(delegation.issuer.as_bytes());
     out.extend_from_slice(delegation.audience.as_bytes());
     match &delegation.capability_origin {
@@ -651,7 +659,7 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
             .try_into()
             .map_err(|_| DecodeError::malformed("invalid signature length"))?,
     );
-    let mut to_verify = WireBytes::from_slice(DST);
+    let mut to_verify = SmallVec::<[u8; 192]>::from_slice(DST);
     to_verify.extend_from_slice(body_bytes);
     delegation
         .issuer
@@ -722,7 +730,7 @@ fn take_key(buf: &mut &[u8]) -> Result<VerifyingKey, DecodeError> {
 }
 
 /// Appends postcard's canonical varint encoding of `value` to `out`.
-fn write_varint(value: u64, out: &mut WireBytes) {
+fn write_varint(value: u64, out: &mut SmallVec<[u8; 192]>) {
     let mut buf = [0u8; 10];
     let encoded = postcard::to_slice(&value, &mut buf).expect("u64 fits in ten bytes");
     out.extend_from_slice(encoded);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,12 @@ use ed25519_dalek::{
 use n0_error::{e, stack_error};
 use n0_future::time::{Duration, SystemTime};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use smallvec::SmallVec;
 
 #[cfg(test)]
 mod tests;
+
+type WireBytes = SmallVec<[u8; 192]>;
 
 /// A grantable capability.
 ///
@@ -47,7 +50,7 @@ pub struct Delegation<C = OpaqueCapability> {
     capability_origin: CapabilityOrigin,
     valid_until: Expires,
     /// The exact capability representation used by the signed payload.
-    capability_bytes: Vec<u8>,
+    capability_bytes: SmallVec<[u8; 32]>,
     signature: Signature,
     capability_type: std::marker::PhantomData<C>,
 }
@@ -58,7 +61,7 @@ impl<C> Delegation<C> {
         audience: VerifyingKey,
         capability_origin: CapabilityOrigin,
         valid_until: Expires,
-        capability_bytes: Vec<u8>,
+        capability_bytes: SmallVec<[u8; 32]>,
         signature: Signature,
     ) -> Self {
         Self {
@@ -131,16 +134,21 @@ impl<C> Delegation<C> {
 
     /// Returns the delegation's byte encoding.
     pub fn encode(&self) -> Vec<u8> {
-        let mut res = vec![2u8];
-        encode_body(self, &mut res);
-        res.extend_from_slice(&self.signature.to_bytes());
-        res
+        self.encode_wire().into_vec()
     }
 
     /// Returns a lowercase base32 string of the delegation's byte encoding,
     /// useful for compact, printable representations.
     pub fn encode_string(&self) -> String {
-        BASE32_LOWER_NOPAD.encode(&self.encode())
+        BASE32_LOWER_NOPAD.encode(&self.encode_wire())
+    }
+
+    fn encode_wire(&self) -> WireBytes {
+        let mut bytes = WireBytes::new();
+        bytes.push(2);
+        encode_body(self, &mut bytes);
+        bytes.extend_from_slice(&self.signature.to_bytes());
+        bytes
     }
 }
 
@@ -175,9 +183,15 @@ impl<C: CapabilityEncoding> Delegation<C> {
     /// Decodes a delegation from a base32 string, verifying the signature and
     /// decoding the capability as `C`. See [`decode`](Delegation::decode).
     pub fn decode_string(s: &str) -> Result<Self, DecodeError> {
-        let bytes = BASE32_LOWER_NOPAD
-            .decode(s.as_bytes())
+        let len = BASE32_LOWER_NOPAD
+            .decode_len(s.len())
             .map_err(DecodeError::malformed)?;
+        let mut bytes = WireBytes::new();
+        bytes.resize(len, 0);
+        let len = BASE32_LOWER_NOPAD
+            .decode_mut(s.as_bytes(), &mut bytes)
+            .map_err(|error| DecodeError::malformed(error.error))?;
+        bytes.truncate(len);
         Self::decode(&bytes)
     }
 }
@@ -222,7 +236,7 @@ impl<C> Serialize for Delegation<C> {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.encode_string())
         } else {
-            let bytes = self.encode();
+            let bytes = self.encode_wire();
             serde_bytes::Bytes::new(&bytes).serialize(serializer)
         }
     }
@@ -248,7 +262,7 @@ impl<'de, C: CapabilityEncoding> Deserialize<'de> for Delegation<C> {
 /// This is the default capability type of a [`Delegation`]: a delegation whose
 /// capability is not (yet) known. Any byte string is a valid `OpaqueCapability`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct OpaqueCapability(Vec<u8>);
+pub struct OpaqueCapability(SmallVec<[u8; 32]>);
 
 impl OpaqueCapability {
     /// Returns the underlying capability bytes.
@@ -259,11 +273,11 @@ impl OpaqueCapability {
 
 impl CapabilityEncoding for OpaqueCapability {
     fn encode(&self) -> Vec<u8> {
-        self.0.clone()
+        self.0.to_vec()
     }
 
     fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
-        Ok(Self(bytes.to_vec()))
+        Ok(Self(SmallVec::from_slice(bytes)))
     }
 }
 
@@ -364,7 +378,7 @@ impl<C: CapabilityEncoding> DelegationBuilder<'_, C> {
     /// Signs the delegation, returning a [`Delegation<C>`] valid until
     /// `valid_until`.
     pub fn sign(self, valid_until: Expires) -> Delegation<C> {
-        let capability_bytes = C::encode(&self.capability);
+        let capability_bytes: SmallVec<[u8; 32]> = C::encode(&self.capability).into();
         let delegation = Delegation::new(
             self.issuer.verifying_key(),
             self.audience,
@@ -373,7 +387,7 @@ impl<C: CapabilityEncoding> DelegationBuilder<'_, C> {
             capability_bytes,
             Signature::from_bytes(&[0u8; 64]),
         );
-        let mut to_sign = DST.to_vec();
+        let mut to_sign = WireBytes::from_slice(DST);
         encode_body(&delegation, &mut to_sign);
         let signature = self.issuer.sign(&to_sign);
         Delegation {
@@ -601,7 +615,7 @@ pub(crate) const BASE32_LOWER_NOPAD: data_encoding::Encoding = data_encoding_mac
     symbols: "abcdefghijklmnopqrstuvwxyz234567",
 );
 
-fn encode_body<C>(delegation: &Delegation<C>, out: &mut Vec<u8>) {
+fn encode_body<C>(delegation: &Delegation<C>, out: &mut WireBytes) {
     out.extend_from_slice(delegation.issuer.as_bytes());
     out.extend_from_slice(delegation.audience.as_bytes());
     match &delegation.capability_origin {
@@ -637,7 +651,7 @@ fn decode_v2_checked<C: CapabilityEncoding>(bytes: &[u8]) -> Result<Delegation<C
             .try_into()
             .map_err(|_| DecodeError::malformed("invalid signature length"))?,
     );
-    let mut to_verify = DST.to_vec();
+    let mut to_verify = WireBytes::from_slice(DST);
     to_verify.extend_from_slice(body_bytes);
     delegation
         .issuer
@@ -674,7 +688,7 @@ fn decode_body<C: CapabilityEncoding>(buf: &mut &[u8]) -> Result<Delegation<C>, 
         .map_err(|_| DecodeError::malformed("capability length overflow"))?;
     let cap_bytes = take_bytes(buf, cap_len)?;
     C::decode(cap_bytes)?;
-    let capability_bytes = cap_bytes.to_vec();
+    let capability_bytes = SmallVec::from_slice(cap_bytes);
 
     Ok(Delegation::new(
         issuer,
@@ -708,7 +722,7 @@ fn take_key(buf: &mut &[u8]) -> Result<VerifyingKey, DecodeError> {
 }
 
 /// Appends postcard's canonical varint encoding of `value` to `out`.
-fn write_varint(value: u64, out: &mut Vec<u8>) {
+fn write_varint(value: u64, out: &mut WireBytes) {
     let mut buf = [0u8; 10];
     let encoded = postcard::to_slice(&value, &mut buf).expect("u64 fits in ten bytes");
     out.extend_from_slice(encoded);


### PR DESCRIPTION
## Description

- Delegation uses a SmallVec<[u8;32]> so small C are zero alloc.
- Use WireBytes type alias to prevent allocations during validation and parsing.

So far no API changes. We could also return a SmallVec from encode or change encode in some way so you can use SmallVec, but that is an API change, so probably best to do it in a separate PR.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
