### PR TITLE
refactor: Remove the somewhat useless builder.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,16 +143,10 @@ impl<C> Delegation<C> {
     /// }
     ///
     /// let key = SigningKey::from_bytes(&[0u8; 32]);
-    /// let typed = Delegation::issue(
-    ///     &key,
-    ///     key.verifying_key(),
-    ///     &Cap::Read,
-    ///     Expires::Never,
-    /// );
+    /// let typed = Delegation::issue(&key, key.verifying_key(), &Cap::Read, Expires::Never);
     /// let opaque = typed.into_opaque();
     /// let back: Delegation<Cap> = opaque.try_with_capability_type().unwrap();
     /// ```
-    ///
     pub fn try_with_capability_type<D: CapabilityEncoding>(
         self,
     ) -> Result<Delegation<D>, DecodeError> {
@@ -428,12 +422,7 @@ impl Authorizer {
     ///
     /// let service = SigningKey::from_bytes(&[0u8; 32]);
     /// let alice = SigningKey::from_bytes(&[1u8; 32]);
-    /// let grant = Delegation::issue(
-    ///     &service,
-    ///     alice.verifying_key(),
-    ///     &Cap::All,
-    ///     Expires::Never,
-    /// );
+    /// let grant = Delegation::issue(&service, alice.verifying_key(), &Cap::All, Expires::Never);
     ///
     /// Authorizer::new(service.verifying_key())
     ///     .check_invocation_from(alice.verifying_key(), Cap::Read, &[&grant])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,17 +137,22 @@ impl<C> Delegation<C> {
     /// use rcan::{Delegation, Expires};
     /// use serde::{Deserialize, Serialize};
     ///
-    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     /// enum Cap {
     ///     Read,
     /// }
     ///
     /// let key = SigningKey::from_bytes(&[0u8; 32]);
-    /// let typed =
-    ///     Delegation::issuing_builder(&key, key.verifying_key(), &Cap::Read).sign(Expires::Never);
+    /// let typed = Delegation::issue(
+    ///     &key,
+    ///     key.verifying_key(),
+    ///     &Cap::Read,
+    ///     Expires::Never,
+    /// );
     /// let opaque = typed.into_opaque();
     /// let back: Delegation<Cap> = opaque.try_with_capability_type().unwrap();
     /// ```
+    ///
     pub fn try_with_capability_type<D: CapabilityEncoding>(
         self,
     ) -> Result<Delegation<D>, DecodeError> {
@@ -179,6 +184,64 @@ impl<C> Delegation<C> {
 }
 
 impl<C: CapabilityEncoding> Delegation<C> {
+    /// Issues `capability` to `audience`, with `issuer` as its origin.
+    pub fn issue(
+        issuer: &SigningKey,
+        audience: VerifyingKey,
+        capability: &C,
+        valid_until: Expires,
+    ) -> Self {
+        Self::sign(
+            issuer,
+            audience,
+            CapabilityOrigin::Issuer,
+            capability,
+            valid_until,
+        )
+    }
+
+    /// Delegates `capability` to `audience`, preserving its original `owner`.
+    pub fn delegate(
+        issuer: &SigningKey,
+        audience: VerifyingKey,
+        owner: VerifyingKey,
+        capability: &C,
+        valid_until: Expires,
+    ) -> Self {
+        Self::sign(
+            issuer,
+            audience,
+            CapabilityOrigin::Delegation(owner),
+            capability,
+            valid_until,
+        )
+    }
+
+    fn sign(
+        issuer: &SigningKey,
+        audience: VerifyingKey,
+        capability_origin: CapabilityOrigin,
+        capability: &C,
+        valid_until: Expires,
+    ) -> Self {
+        let capability_bytes = C::encode(capability);
+        let delegation = Delegation::new(
+            issuer.verifying_key(),
+            audience,
+            capability_origin,
+            valid_until,
+            capability_bytes,
+            Signature::from_bytes(&[0u8; 64]),
+        );
+        let mut to_sign = DST.to_vec();
+        encode_body(&delegation, &mut to_sign);
+        let signature = issuer.sign(&to_sign);
+        Delegation {
+            signature,
+            ..delegation
+        }
+    }
+
     /// Decodes and returns the capability from the signed payload.
     pub fn capability(&self) -> C {
         C::decode(&self.capability_bytes)
@@ -213,39 +276,6 @@ impl<C: CapabilityEncoding> Delegation<C> {
             .decode(s.as_bytes())
             .map_err(DecodeError::malformed)?;
         Self::decode(&bytes)
-    }
-}
-
-impl<C: Clone> Delegation<C> {
-    /// Returns a builder for a delegation that `issuer` issues to `audience`
-    /// for `capability`, where `issuer` is the origin of the capability.
-    pub fn issuing_builder<'s>(
-        issuer: &'s SigningKey,
-        audience: VerifyingKey,
-        capability: &C,
-    ) -> DelegationBuilder<'s, C> {
-        DelegationBuilder {
-            issuer,
-            audience,
-            capability_origin: CapabilityOrigin::Issuer,
-            capability: capability.clone(),
-        }
-    }
-
-    /// Returns a builder for a delegation that `issuer` issues to `audience`
-    /// for `capability`, where the capability was originally held by `owner`.
-    pub fn delegating_builder<'s>(
-        issuer: &'s SigningKey,
-        audience: VerifyingKey,
-        owner: VerifyingKey,
-        capability: &C,
-    ) -> DelegationBuilder<'s, C> {
-        DelegationBuilder {
-            issuer,
-            audience,
-            capability_origin: CapabilityOrigin::Delegation(owner),
-            capability: capability.clone(),
-        }
     }
 }
 
@@ -352,37 +382,6 @@ impl Expires {
     }
 }
 
-/// Builds and signs a [`Delegation`].
-pub struct DelegationBuilder<'s, C> {
-    issuer: &'s SigningKey,
-    audience: VerifyingKey,
-    capability_origin: CapabilityOrigin,
-    capability: C,
-}
-
-impl<C: CapabilityEncoding> DelegationBuilder<'_, C> {
-    /// Signs the delegation, returning a [`Delegation<C>`] valid until
-    /// `valid_until`.
-    pub fn sign(self, valid_until: Expires) -> Delegation<C> {
-        let capability_bytes = C::encode(&self.capability);
-        let delegation = Delegation::new(
-            self.issuer.verifying_key(),
-            self.audience,
-            self.capability_origin,
-            valid_until,
-            capability_bytes,
-            Signature::from_bytes(&[0u8; 64]),
-        );
-        let mut to_sign = DST.to_vec();
-        encode_body(&delegation, &mut to_sign);
-        let signature = self.issuer.sign(&to_sign);
-        Delegation {
-            signature,
-            ..delegation
-        }
-    }
-}
-
 /// The authority that verifies an invocation.
 ///
 /// An [`Authorizer`] holds the public key of the principal that first issued a
@@ -415,11 +414,12 @@ impl Authorizer {
     /// use rcan::{Authorizer, Capability, Delegation, Expires};
     /// use serde::{Deserialize, Serialize};
     ///
-    /// #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     /// enum Cap {
     ///     Read,
     ///     All,
     /// }
+    ///
     /// impl Capability for Cap {
     ///     fn permits(&self, other: &Self) -> bool {
     ///         *self == Cap::All || self == other
@@ -428,12 +428,14 @@ impl Authorizer {
     ///
     /// let service = SigningKey::from_bytes(&[0u8; 32]);
     /// let alice = SigningKey::from_bytes(&[1u8; 32]);
+    /// let grant = Delegation::issue(
+    ///     &service,
+    ///     alice.verifying_key(),
+    ///     &Cap::All,
+    ///     Expires::Never,
+    /// );
     ///
-    /// let grant = Delegation::issuing_builder(&service, alice.verifying_key(), &Cap::All)
-    ///     .sign(Expires::Never);
-    ///
-    /// let authorizer = Authorizer::new(service.verifying_key());
-    /// authorizer
+    /// Authorizer::new(service.verifying_key())
     ///     .check_invocation_from(alice.verifying_key(), Cap::Read, &[&grant])
     ///     .unwrap();
     /// ```

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,8 +35,12 @@ fn key(seed: u8) -> SigningKey {
 }
 
 fn delegation() -> Delegation<Rpc> {
-    Delegation::issuing_builder(&key(0), key(1).verifying_key(), &Rpc::ReadWrite)
-        .sign(Expires::At(4_102_444_800))
+    Delegation::issue(
+        &key(0),
+        key(1).verifying_key(),
+        &Rpc::ReadWrite,
+        Expires::At(4_102_444_800),
+    )
 }
 
 fn hexdump(s: &str) -> Vec<u8> {
@@ -90,8 +94,7 @@ fn wire_snapshots() {
     assert_eq!(v2.capability_owner(), &key(0).verifying_key());
     assert_eq!(v2.capability(), Rpc::ReadWrite);
 
-    let never = Delegation::issuing_builder(&key(0), key(1).verifying_key(), &Rpc::All)
-        .sign(Expires::Never);
+    let never = Delegation::issue(&key(0), key(1).verifying_key(), &Rpc::All, Expires::Never);
     assert_eq!(hex::encode(never.encode()), hex::encode(hexdump(V2_NEVER)));
     assert_eq!(
         Delegation::<Rpc>::decode(&hexdump(V2_NEVER)).unwrap(),
@@ -153,9 +156,8 @@ fn minicbor_serde_roundtrip() {
 
 #[test]
 fn v2_decode_rejects_tampering() {
-    let good = Delegation::issuing_builder(&key(0), key(1).verifying_key(), &Rpc::Read)
-        .sign(Expires::Never)
-        .encode();
+    let good =
+        Delegation::issue(&key(0), key(1).verifying_key(), &Rpc::Read, Expires::Never).encode();
 
     let mut forged = good.clone();
     let n = forged.len();
@@ -262,8 +264,7 @@ fn hashmap_capability_roundtrips() {
     let capability: std::collections::HashMap<u64, u64> =
         (0..64).map(|value| (value, value * 2)).collect();
 
-    let delegation =
-        Delegation::issuing_builder(&issuer, audience, &capability).sign(Expires::Never);
+    let delegation = Delegation::issue(&issuer, audience, &capability, Expires::Never);
     let encoded = delegation.encode();
     let decoded = Delegation::<std::collections::HashMap<u64, u64>>::decode(&encoded).unwrap();
 
@@ -276,16 +277,20 @@ fn two_link_chain_invocation() {
     let alice = key(1);
     let bob = key(2);
 
-    let root = Delegation::issuing_builder(&service, alice.verifying_key(), &Rpc::All)
-        .sign(Expires::At(4_102_444_800));
+    let root = Delegation::issue(
+        &service,
+        alice.verifying_key(),
+        &Rpc::All,
+        Expires::At(4_102_444_800),
+    );
 
-    let link = Delegation::delegating_builder(
+    let link = Delegation::delegate(
         &alice,
         bob.verifying_key(),
         service.verifying_key(),
         &Rpc::Read,
-    )
-    .sign(Expires::Never);
+        Expires::Never,
+    );
 
     let authorizer = Authorizer::new(service.verifying_key());
     let chain = [&root, &link];
@@ -338,8 +343,7 @@ fn chain_must_start_at_the_authorizer() {
     let alice = key(1);
     let bob = key(2);
 
-    let alice_grant =
-        Delegation::issuing_builder(&alice, bob.verifying_key(), &Rpc::All).sign(Expires::Never);
+    let alice_grant = Delegation::issue(&alice, bob.verifying_key(), &Rpc::All, Expires::Never);
     let authorizer = Authorizer::new(service.verifying_key());
     let err = authorizer
         .check_invocation_from(bob.verifying_key(), Rpc::Read, &[&alice_grant])
@@ -354,13 +358,13 @@ fn subject_must_be_the_authorizer() {
     let other = key(1);
     let alice = key(2);
 
-    let foreign_grant = Delegation::delegating_builder(
+    let foreign_grant = Delegation::delegate(
         &service,
         alice.verifying_key(),
         other.verifying_key(),
         &Rpc::All,
-    )
-    .sign(Expires::Never);
+        Expires::Never,
+    );
     let authorizer = Authorizer::new(service.verifying_key());
     let err = authorizer
         .check_invocation_from(alice.verifying_key(), Rpc::Read, &[&foreign_grant])


### PR DESCRIPTION
## Description

New API is just 2 fns on Delegation directly.

## Breaking Changes

Builder API is removed.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
